### PR TITLE
💥: initial running no-op plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM golang:1.14 as build-env
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
 WORKDIR /tmp/secrets-store-csi-driver-provider-gcp
 COPY . ./
-RUN CGO_ENABLED=0 go install github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
+RUN go install \
+    -trimpath \
+    -ldflags "-extldflags '-static'" \
+    github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
 
 FROM gcr.io/distroless/base
 COPY --from=build-env /go/bin/secrets-store-csi-driver-provider-gcp /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.14 as build-env
+WORKDIR /tmp/secrets-store-csi-driver-provider-gcp
+COPY . ./
+RUN CGO_ENABLED=0 go install github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
+
+FROM gcr.io/distroless/base
+COPY --from=build-env /go/bin/secrets-store-csi-driver-provider-gcp /bin/
+ENTRYPOINT ["/bin/secrets-store-csi-driver-provider-gcp", "-daemonset"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,30 @@ the [Secret Store CSI
 Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver). Allows you
 to access secrets stored in Secret Manager as files mounted in Kubernetes pods.
 
+## Build and deploy notes
+
+**WARNING:** These are preliminary notes to aid in development, this plugin is currently not functional.
+
+* Create a new GKE cluster with K8S 1.16+
+* Install [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) to the cluster.
+```shell
+$ kubectl apply -f deploy/rbac-secretproviderclass.yaml
+$ kubectl apply -f deploy/csidriver.yaml
+$ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+$ kubectl apply -f deploy/secrets-store-csi-driver.yaml
+```
+* Use [Google Cloud Build](https://cloud.google.com/run/docs/building/containers#building_using) and [Container Registry](https://cloud.google.com/container-registry/docs/quickstart) to build and host the plugin docker image.
+```shell
+$ export PROJECT_ID=<your gcp project>
+$ ./scripts/build.sh
+```
+* Deploy the plugin as a DaemonSet to your cluster.
+```shell
+$ ./scripts/deploy.sh
+```
+* Try it out the example which attempts to mount the secret "test" in `$PROJECT_ID` to `/var/secrets/good1.txt` and `/var/secrets/good2.txt`
+```shell
+$ ./scripts/example.sh
+$ kubectl exec -it mypod /bin/bash
+root@mypod:/# ls /var/secrets
+```

--- a/deploy/provider-gcp-plugin.yaml.tmpl
+++ b/deploy/provider-gcp-plugin.yaml.tmpl
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-gcp
+  name: csi-secrets-store-provider-gcp
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-gcp
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-gcp
+    spec:
+      containers:
+        - name: provider-gcp-installer
+          image: gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+              path: /etc/kubernetes/secrets-store-csi-providers
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/examples/app-secrets.yaml.tmpl
+++ b/examples/app-secrets.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: app-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      array:
+        - |
+          name: "projects/$PROJECT_ID/secrets/test/versions/latest"
+          path: "good1.txt"
+        - |
+          name: "projects/$PROJECT_ID/secrets/test/versions/latest"
+          path: "good2.txt"

--- a/examples/mypod.yaml.tmpl
+++ b/examples/mypod.yaml.tmpl
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mypod
+  namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+  namespace: default
+spec:
+  serviceAccountName: mypod
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: mypod
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+      - mountPath: "/var/secrets"
+        name: mysecret
+  volumes:
+  - name: mysecret
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "app-secrets"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
+
+go 1.14

--- a/main.go
+++ b/main.go
@@ -91,8 +91,7 @@ func copyself(ctx context.Context) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(pluginPath, self, 0755)
-	if err != nil {
+	if err := ioutil.WriteFile(pluginPath, self, 0755); err != nil {
 		return err
 	}
 
@@ -106,22 +105,19 @@ func plugin(ctx context.Context) error {
 	var filePermission os.FileMode
 
 	// Everything in the "parameters" section of the SecretProviderClass.
-	err := json.Unmarshal([]byte(*attributes), &attrib)
-	if err != nil {
+	if err := json.Unmarshal([]byte(*attributes), &attrib); err != nil {
 		return fmt.Errorf("failed to unmarshal attributes, err: %v", err)
 	}
 
 	// The secrets here are the relevant CSI driver (k8s) secrets. See
 	// https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html
 	// Currently unused.
-	err = json.Unmarshal([]byte(*secrets), &secret)
-	if err != nil {
+	if err := json.Unmarshal([]byte(*secrets), &secret); err != nil {
 		return fmt.Errorf("failed to unmarshal secrets, err: %v", err)
 	}
 
 	// Permissions to apply to all files.
-	err = json.Unmarshal([]byte(*permission), &filePermission)
-	if err != nil {
+	if err := json.Unmarshal([]byte(*permission), &filePermission); err != nil {
 		return fmt.Errorf("failed to unmarshal file permission, err: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	// This plugin and the github.com/kubernetes-sigs/secrets-store-csi-driver
 	// driver are both installed as DaemonSets that share a common folder on
 	// the host. When the "-daemonset" flag is set this binary copies itself
-	// to the TARGET_DIR folder and sleeps indefinately.
+	// to the TARGET_DIR folder and sleeps indefinitely.
 	if *daemonset {
 		if err := copyself(ctx); err != nil {
 			log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,10 @@ var (
 	permission = flag.String("permission", "", "File permissions of the written secrets")
 )
 
+// The "provider" name in the "SecretProviderClass" CRD that this plugin
+// operates on.
+const providerName = "gcp"
+
 func main() {
 	flag.Parse()
 	// TODO: https://github.com/kubernetes-sigs/secrets-store-csi-driver does
@@ -73,15 +77,15 @@ func copyself(ctx context.Context) error {
 		return err
 	}
 
-	pluginDir := filepath.Join(td, "gcp")
-	pluginPath := filepath.Join(pluginDir, "provider-gcp")
+	pluginDir := filepath.Join(td, providerName)
+	pluginPath := filepath.Join(pluginDir, "provider-"+providerName)
 	defer func() {
 		// Attempt to cleanup since we are creating a folder and writing a
 		// binary to a hostPath
 		log.Printf("cleanup %v: %v", pluginDir, os.RemoveAll(pluginDir))
 	}()
 
-	if err := os.MkdirAll(filepath.Join(td, "gcp"), 0755); err != nil {
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -78,8 +78,7 @@ func copyself(ctx context.Context) error {
 	defer func() {
 		// Attempt to cleanup since we are creating a folder and writing a
 		// binary to a hostPath
-		log.Printf("cleanup %v: %v", pluginPath, os.Remove(pluginPath))
-		log.Printf("cleanup %v: %v", pluginDir, os.Remove(pluginDir))
+		log.Printf("cleanup %v: %v", pluginDir, os.RemoveAll(pluginDir))
 	}()
 
 	if err := os.MkdirAll(filepath.Join(td, "gcp"), 0755); err != nil {

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func copyself(ctx context.Context) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(pluginPath, self, 0755); err != nil {
+	if err := ioutil.WriteFile(pluginPath, self, 0754); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+var (
+	daemonset = flag.Bool("daemonset", false, "Controls whether the plugin executes in the DaemonSet mode, copying itself to TARGET_DIR")
+
+	attributes = flag.String("attributes", "", "Secrets volume attributes.")
+	secrets    = flag.String("secrets", "", "Kubernetes secrets passed through the CSI driver node publish interface.")
+	targetPath = flag.String("targetPath", "", "Path to where the secrets should be written")
+	permission = flag.String("permission", "", "File permissions of the written secrets")
+)
+
+func main() {
+	flag.Parse()
+	// TODO: https://github.com/kubernetes-sigs/secrets-store-csi-driver does
+	// not log plugin stderr output.
+	log.SetOutput(os.Stdout)
+	ctx := withShutdownSignal(context.Background())
+
+	// This plugin and the github.com/kubernetes-sigs/secrets-store-csi-driver
+	// driver are both installed as DaemonSets that share a common folder on
+	// the host. When the "-daemonset" flag is set this binary copies itself
+	// to the TARGET_DIR folder and sleeps indefinately.
+	if *daemonset {
+		if err := copyself(ctx); err != nil {
+			log.Fatal(err)
+		}
+		os.Exit(0)
+	}
+
+	// Fetch and write secrets.
+	if err := plugin(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// withShutdownSignal returns a copy of the parent context that will close if
+// the process receives termination signals.
+func withShutdownSignal(ctx context.Context) context.Context {
+	nctx, cancel := context.WithCancel(ctx)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+
+	go func() {
+		sig := <-sigs
+		log.Println("signal:", sig)
+		cancel()
+	}()
+	return nctx
+}
+
+// copyself copies the current binary to the correct path in TARGET_DIR and
+// then sleeps until the context done signal is received.
+func copyself(ctx context.Context) error {
+	td := os.Getenv("TARGET_DIR")
+	if td == "" {
+		return errors.New("TARGET_DIR not set")
+	}
+	if _, err := os.Stat(td); err != nil {
+		return err
+	}
+
+	pluginDir := filepath.Join(td, "gcp")
+	pluginPath := filepath.Join(pluginDir, "provider-gcp")
+	defer func() {
+		// Attempt to cleanup since we are creating a folder and writing a
+		// binary to a hostPath
+		log.Printf("cleanup %v: %v", pluginPath, os.Remove(pluginPath))
+		log.Printf("cleanup %v: %v", pluginDir, os.Remove(pluginDir))
+	}()
+
+	if err := os.MkdirAll(filepath.Join(td, "gcp"), 0755); err != nil {
+		return err
+	}
+
+	self, err := ioutil.ReadFile(os.Args[0])
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(pluginPath, self, 0755)
+	if err != nil {
+		return err
+	}
+
+	<-ctx.Done()
+	log.Printf("terminating")
+	return nil
+}
+
+func plugin(ctx context.Context) error {
+	var attrib, secret map[string]string
+	var filePermission os.FileMode
+
+	// Everything in the "parameters" section of the SecretProviderClass.
+	err := json.Unmarshal([]byte(*attributes), &attrib)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal attributes, err: %v", err)
+	}
+
+	// The secrets here are the relevant CSI driver (k8s) secrets. See
+	// https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html
+	// Currently unused.
+	err = json.Unmarshal([]byte(*secrets), &secret)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal secrets, err: %v", err)
+	}
+
+	// Permissions to apply to all files.
+	err = json.Unmarshal([]byte(*permission), &filePermission)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal file permission, err: %v", err)
+	}
+
+	log.Printf("attributes: %v", attrib)
+	log.Printf("secrets: %v", secret)
+	log.Printf("filePermission: %v", filePermission)
+	log.Printf("targetPath: %v", *targetPath)
+
+	// TODO: actually fetch and write secrets.
+	return nil
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit  # Exit with error on non-zero exit codes
+set -o pipefail # Check the exit code of *all* commands in a pipeline
+set -o nounset  # Error if accessing an unbound variable
+set -x          # Print each command as it is run
+
+gcloud builds submit --tag gcr.io/${PROJECT_ID}/secrets-store-csi-driver-provider-gcp

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit  # Exit with error on non-zero exit codes
+set -o pipefail # Check the exit code of *all* commands in a pipeline
+set -o nounset  # Error if accessing an unbound variable
+set -x          # Print each command as it is run
+
+sed "s/\$PROJECT_ID/${PROJECT_ID}/g" deploy/provider-gcp-plugin.yaml.tmpl | kubectl apply -f -

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit  # Exit with error on non-zero exit codes
+set -o pipefail # Check the exit code of *all* commands in a pipeline
+set -o nounset  # Error if accessing an unbound variable
+set -x          # Print each command as it is run
+
+sed "s/\$PROJECT_ID/${PROJECT_ID}/g" examples/app-secrets.yaml.tmpl | kubectl apply -f -
+sed "s/\$PROJECT_ID/${PROJECT_ID}/g" examples/mypod.yaml.tmpl | kubectl apply -f -


### PR DESCRIPTION
Adds a run-able binary that conforms to the [driver interface](https://github.com/kubernetes-sigs/secrets-store-csi-driver#criteria-for-supported-providers).

The deploy mechanism is similar to the azure and vault plugins (deploy a `DaemonSet` that copies the binary to a directory on the host), but I decided to do that in the go-code itself rather than as an entrypoint script.

A follow up PR will actually read from the Secret Manager API.