### PR TITLE
typo: missing capital letter skipped test

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -73,7 +73,7 @@ func TestHandleMountEvent(t *testing.T) {
 	}
 }
 
-func TesthandleMountEventSMError(t *testing.T) {
+func TestHandleMountEventSMError(t *testing.T) {
 	dir := driveMountHelper(t)
 
 	client := mock(t, &mockSecretServer{


### PR DESCRIPTION
This test wasn't running because of a typo in the test name