### PR TITLE
SecretProviderClass: remove nesting for secrets parameter

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,7 @@ func TestParse(t *testing.T) {
 			in: &MountParams{
 				Attributes: `
 				{
-					"secrets": "array:\n  - |\n    resourceName: \"projects/project/secrets/test/versions/latest\"\n    fileName: \"good1.txt\"\n",
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n",
 					"csi.storage.k8s.io/pod.namespace": "default",
 					"csi.storage.k8s.io/pod.name": "mypod",
 					"csi.storage.k8s.io/pod.uid": "123"
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 			in: &MountParams{
 				Attributes: `
 				{
-					"secrets": "array:\n  - |\n    resourceName: \"projects/project/secrets/test/versions/latest\"\n    fileName: \"good1.txt\"\n  - |\n    resourceName: \"projects/project/secrets/test2/versions/latest\"\n    fileName: \"good2.txt\"\n",
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n- resourceName: \"projects/project/secrets/test2/versions/latest\"\n  fileName: \"good2.txt\"\n",
 					"csi.storage.k8s.io/pod.namespace": "default",
 					"csi.storage.k8s.io/pod.name": "mypod",
 					"csi.storage.k8s.io/pod.uid": "123"
@@ -121,7 +121,7 @@ func TestParseErrors(t *testing.T) {
 			in: &MountParams{
 				Attributes: `
 				{
-					"secrets": "array:\n  - |\n    resourceName: \"projects/project/secrets/test/versions/latest\"\n    fileName: \"good1.txt\"\n",
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n",
 					"csi.storage.k8s.io/pod.namespace": "default",
 					"csi.storage.k8s.io/pod.name": "mypod",
 					"csi.storage.k8s.io/pod.uid": "123"

--- a/examples/app-secrets.yaml.tmpl
+++ b/examples/app-secrets.yaml.tmpl
@@ -6,10 +6,7 @@ spec:
   provider: gcp
   parameters:
     secrets: |
-      array:
-        - |
-          resourceName: "projects/$PROJECT_ID/secrets/testsecret/versions/latest"
-          fileName: "good1.txt"
-        - |
-          resourceName: "projects/$PROJECT_ID/secrets/testsecret/versions/latest"
-          fileName: "good2.txt"
+      - resourceName: "projects/$PROJECT_ID/secrets/testsecret/versions/latest"
+        fileName: "good1.txt"
+      - resourceName: "projects/$PROJECT_ID/secrets/testsecret/versions/latest"
+        fileName: "good2.txt"


### PR DESCRIPTION
Fixes #6 

The main driver only interprets the top level `parameters` dictionary. So long as all values in that dictionary are strings it should match the schema.