### PR TITLE
Dockerfile: use smaller static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go get -t ./...
 RUN make licensessave
 RUN go install \
     -trimpath \
-    -ldflags "-extldflags '-static'" \
+    -ldflags "-s -w -extldflags '-static'" \
     github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
 
 FROM gcr.io/distroless/static-debian10

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go install \
     -ldflags "-extldflags '-static'" \
     github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static-debian10
 COPY --from=build-env /tmp/secrets-store-csi-driver-provider-gcp/licenses /licenses
 COPY --from=build-env /go/bin/secrets-store-csi-driver-provider-gcp /bin/
 ENTRYPOINT ["/bin/secrets-store-csi-driver-provider-gcp", "-daemonset"]


### PR DESCRIPTION
distroless now recommends referencing debian 9 or debian 10 variants of their images: https://github.com/GoogleContainerTools/distroless#base-operating-system

Also we build as a static binary so we do not need everything included in the `base` variant: https://github.com/GoogleContainerTools/distroless/tree/master/base#documentation-for-gcriodistrolessbase-and-gcriodistrolessstatic

Cuts the image size from 60.4MiB to 44.9MiB.