### PR TITLE
auth: remove GET Pod when SA is passed by driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ to access secrets stored in Secret Manager as files mounted in Kubernetes pods.
 ## Install
 
 * Create a new GKE cluster with K8S 1.16+
-* Install [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) to the cluster.
+* Install [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) v0.0.13 or higher to the cluster.
 ```shell
 $ kubectl apply -f deploy/rbac-secretproviderclass.yaml
 $ kubectl apply -f deploy/csidriver.yaml
 $ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+$ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 $ kubectl apply -f deploy/secrets-store-csi-driver.yaml
 ```
 * Install the plugin DaemonSet & additional RoleBindings

--- a/config/config.go
+++ b/config/config.go
@@ -40,9 +40,10 @@ type Secret struct {
 
 // PodInfo includes details about the pod that is receiving the mount event.
 type PodInfo struct {
-	Namespace string
-	Name      string
-	UID       types.UID
+	Namespace      string
+	Name           string
+	UID            types.UID
+	ServiceAccount string
 }
 
 // MountConfig holds the parsed information from a mount event.
@@ -76,9 +77,10 @@ func Parse(in *MountParams) (*MountConfig, error) {
 	}
 
 	out.PodInfo = &PodInfo{
-		Namespace: attrib["csi.storage.k8s.io/pod.namespace"],
-		Name:      attrib["csi.storage.k8s.io/pod.name"],
-		UID:       types.UID(attrib["csi.storage.k8s.io/pod.uid"]),
+		Namespace:      attrib["csi.storage.k8s.io/pod.namespace"],
+		Name:           attrib["csi.storage.k8s.io/pod.name"],
+		UID:            types.UID(attrib["csi.storage.k8s.io/pod.uid"]),
+		ServiceAccount: attrib["csi.storage.k8s.io/serviceAccount.name"],
 	}
 
 	// The secrets here are the relevant CSI driver (k8s) secrets. See

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,8 @@ func TestParse(t *testing.T) {
 					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n",
 					"csi.storage.k8s.io/pod.namespace": "default",
 					"csi.storage.k8s.io/pod.name": "mypod",
-					"csi.storage.k8s.io/pod.uid": "123"
+					"csi.storage.k8s.io/pod.uid": "123",
+					"csi.storage.k8s.io/serviceAccount.name": "mysa"
 				}
 				`,
 				KubeSecrets: "{}",
@@ -49,9 +50,10 @@ func TestParse(t *testing.T) {
 					},
 				},
 				PodInfo: &PodInfo{
-					Namespace: "default",
-					Name:      "mypod",
-					UID:       "123",
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
 				},
 				TargetPath:  "/tmp/foo",
 				Permissions: 777,
@@ -65,7 +67,8 @@ func TestParse(t *testing.T) {
 					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n- resourceName: \"projects/project/secrets/test2/versions/latest\"\n  fileName: \"good2.txt\"\n",
 					"csi.storage.k8s.io/pod.namespace": "default",
 					"csi.storage.k8s.io/pod.name": "mypod",
-					"csi.storage.k8s.io/pod.uid": "123"
+					"csi.storage.k8s.io/pod.uid": "123",
+					"csi.storage.k8s.io/serviceAccount.name": "mysa"
 				}
 				`,
 				KubeSecrets: "{}",
@@ -84,9 +87,10 @@ func TestParse(t *testing.T) {
 					},
 				},
 				PodInfo: &PodInfo{
-					Namespace: "default",
-					Name:      "mypod",
-					UID:       "123",
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
 				},
 				TargetPath:  "/tmp/foo",
 				Permissions: 777,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -12,7 +12,7 @@ E2E tests run a simple test binary (test secret mounter) that reads a secret fro
 
 ```sh
 $ export PROJECT_ID=myprojectid
-$ export SECRET_STORE_VERSION=v0.0.12
+$ export SECRET_STORE_VERSION=v0.0.13
 $ export GCP_PROVIDER_BRANCH=main
 $ ./build.sh
 ```


### PR DESCRIPTION
If https://github.com/kubernetes-sigs/secrets-store-csi-driver passed along the `csi.storage.k8s.io/serviceAccount.name` attribute then we could eliminate the call to get the information about the pod for the mount event.

It also lets us remove the pod get permission.

https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/1855-csi-driver-service-account-token/README.md would be even nicer as it would let us remove the `serviceaccounts/token` `create` permission, but that may take much longer to land. 

Blocked by https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/267