### PR TITLE
build: provide a pre-built image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the [Secret Store CSI
 Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver). Allows you
 to access secrets stored in Secret Manager as files mounted in Kubernetes pods.
 
-## Build and deploy notes
+## Install
 
 * Create a new GKE cluster with K8S 1.16+
 * Install [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) to the cluster.
@@ -18,6 +18,14 @@ $ kubectl apply -f deploy/csidriver.yaml
 $ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 $ kubectl apply -f deploy/secrets-store-csi-driver.yaml
 ```
+* Install the plugin DaemonSet & additional RoleBindings
+```shell
+$ kubectl apply -f deploy/workload-id-binding.yaml
+$ kubectl apply -f deploy/provider-gcp-plugin.yaml
+```
+
+## Build and deploy notes
+
 * Use [Google Cloud Build](https://cloud.google.com/run/docs/building/containers#building_using) and [Container Registry](https://cloud.google.com/container-registry/docs/quickstart) to build and host the plugin docker image.
 ```shell
 $ export PROJECT_ID=<your gcp project>
@@ -28,9 +36,14 @@ $ ./scripts/build.sh
 ```shell
 $ ./scripts/deploy.sh
 ```
+
+## Usage
+
 * Ensure that workload identity is [enabled](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_on_existing_cluster) in your GKE cluster.
 * Setup the workload identity service account.
 ```shell
+$ export PROJECT_ID=<your gcp project>
+$ gcloud config set project $PROJECT_ID
 # Create a service account for workload identity
 $ gcloud iam service-accounts create gke-workload
 

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-gcp
+  name: csi-secrets-store-provider-gcp
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-gcp
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-gcp
+    spec:
+      containers:
+        - name: provider-gcp-installer
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:e8b491a72eb3f3337005565470972f41c52a8de47fc5266d6bf3e2a94d88df26
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+              path: /etc/kubernetes/secrets-store-csi-providers
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: provider-gcp-installer
           image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:e8b491a72eb3f3337005565470972f41c52a8de47fc5266d6bf3e2a94d88df26
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 50m

--- a/scripts/cloudbuild.yaml
+++ b/scripts/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# Clone plugin @ HEAD and build/publish Docker Image
+#
+# gcloud builds submit --config scripts/cloudbuild.yaml --no-source
+#
+# Requires permission for Cloud Build and the secretmanager-csi Artifact
+# Registry repos.
+timeout: 600s
+options:
+  machineType: N1_HIGHCPU_8
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['clone', 'https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp']
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build',
+          '-t', 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
+          '-t', 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
+          '-t', 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
+          'secrets-store-csi-driver-provider-gcp' ]
+images:
+- 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'
+- 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'
+- 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'


### PR DESCRIPTION
Resolves #10. Builds & pushes must still be triggered manually.

Blocked on permissions to `*-docker.pkg.dev/secretmanager-csi` being expanded to `allUsers`.