### PR TITLE
Use neutral locale for misspell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ fmtcheck:
 
 spellcheck:
 	@command -v misspell > /dev/null 2>&1 || (cd tools && go get github.com/client9/misspell/cmd/misspell && cd ..)
-	@misspell -locale="US" -error -source="text" **/*
+	@misspell -error -source="text" **/*
 .PHONY: spellcheck
 
 staticcheck:


### PR DESCRIPTION
Currently, misspell marks UK spellings as incorrect (e.g. "cancelled"). This reverts it to the default of allowing all valid english spellings.