### PR TITLE
Use https instead of SSH to clone repo for ACM

### DIFF
--- a/test/infra/configs/config-management.yaml
+++ b/test/infra/configs/config-management.yaml
@@ -6,7 +6,7 @@ spec:
   # main GKE cluster used to run integration tests and create other GKE clusters
   clusterName: management-cluster
   git:
-    syncRepo: git@github.com:GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp.git
+    syncRepo: https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp.git
     syncBranch: main
     secretType: none
     policyDir: "test/infra/anthos-managed"


### PR DESCRIPTION
SSH fails with

```
"Cloning into '/repo'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
" }
```

Since this is a public repo, we can just clone with HTTPS