### PR TITLE
Explicitly quote environment variables

### DIFF
--- a/test/e2e/e2e-test-job.yaml.tmpl
+++ b/test/e2e/e2e-test-job.yaml.tmpl
@@ -16,6 +16,6 @@ spec:
           imagePullPolicy: Always
           env:
           - name: GCP_PROVIDER_BRANCH
-            value: $GCP_PROVIDER_BRANCH
+            value: "$GCP_PROVIDER_BRANCH"
           - name: PROJECT_ID
-            value: $PROJECT_ID
+            value: "$PROJECT_ID"


### PR DESCRIPTION
This ensures that they're parsed as strings, even when they comprise of all numbers