### PR TITLE
DEBUG: introduce a DEBUG envvar to print extra information

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,9 +90,13 @@ func Parse(in *MountParams) (*MountConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal secrets: %v", err)
 	}
 
-	// TODO(#4): redact attributes + secrets (or make configurable)
-	log.Printf("attributes: %v", attrib)
-	log.Printf("secrets: %v", secret)
+	if os.Getenv("DEBUG") == "true" {
+		log.Printf("attributes: %v", attrib)
+		log.Printf("secrets: %v", secret)
+	} else {
+		log.Printf("attributes: REDACTED (envvar DEBUG=true to see values)")
+		log.Printf("secrets: REDACTED (envvar DEBUG=true to see values)")
+	}
 	log.Printf("filePermission: %v", in.Permissions)
 	log.Printf("targetPath: %v", in.TargetPath)
 


### PR DESCRIPTION
This would need to be set in the CSI driver DaemonSet NOT in the plugin DaemonSet to print information during actual mount events.

Fixes #4 