### PR TITLE
Grant cloud build service account permissions

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -47,6 +47,13 @@ spec:
       - serviceAccount:735463103342@cloudservices.gserviceaccount.com
       - serviceAccount:service-735463103342@containerregistry.iam.gserviceaccount.com
       role: roles/editor
+    # for Cloud Build to build and upload to GCR
+    - members:
+      - serviceAccount:735463103342@cloudbuild.gserviceaccount.com
+      role: roles/storage.admin
+    - members:
+      - serviceAccount:735463103342@cloudbuild.gserviceaccount.com
+      role: roles/cloudbuild.builds.editor
     # TODO: replace with secret manager team
     - members:
       - user:colinman@google.com


### PR DESCRIPTION
In preparation for moving the `docker` commands in `test/e2e/build.sh` to Cloud Build. Currently, a build errors with 

```
AccessDeniedException: 403 735463103342@cloudbuild.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket.
```

https://cloud.google.com/cloud-build/docs/cloud-build-service-account#default_permissions_of_service_account outlines the required permissions.