### PR TITLE
Grant Cloud Build SA cloudbuild.builds.builder

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -50,10 +50,7 @@ spec:
     # for Cloud Build to build and upload to GCR
     - members:
       - serviceAccount:735463103342@cloudbuild.gserviceaccount.com
-      role: roles/storage.admin
-    - members:
-      - serviceAccount:735463103342@cloudbuild.gserviceaccount.com
-      role: roles/cloudbuild.builds.editor
+      role: roles/cloudbuild.builds.builder
     # TODO: replace with secret manager team
     - members:
       - user:colinman@google.com


### PR DESCRIPTION
Even with the current permissions, we're getting the error

```
 service account "735463103342@cloudbuild.gserviceaccount.com" has insufficient permission to execute the build on project "secretmanager-csi-build"
```

This restores the "Cloud Build Service Account" role per https://cloud.google.com/iam/docs/understanding-roles#cloud-build-roles