### PR TITLE
test infra: add resources to use with integration testing

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
@@ -1,0 +1,55 @@
+  # Copyright 2020 Google LLC
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: k8s-csi-test
+spec:
+  displayName: Integration Tests Service Account
+---
+apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+kind: SecretManagerSecret
+metadata:
+  name: test-secret-a
+  labels:
+    replication-type: automatic
+spec:
+  replication:
+    automatic: true
+---
+  apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+  kind: SecretManagerSecretVersion
+  metadata:
+    name: test-secret-a-version
+  spec:
+    enabled: true
+    secretData:
+      # "hunter2"
+      value: "aHVudGVyMg=="
+    secretRef:
+      name: test-secret-a
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: test-secret-a-binding
+spec:
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    name: test-secret-a
+  bindings:
+    - role: roles/secretmanager.secretAccessor
+      members:
+        - serviceAccount:k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com


### PR DESCRIPTION
Create a service account and a test secret in the build project for
use by integration tests. The SA will have permissions to read the
secret.

The secret value is 'hunter2' and is a test value only, it provides no
access to any external systems!

Create the static assets for https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/12 and the integration tests that will be needed for https://github.com/kubernetes-sigs/secrets-store-csi-driver#criteria-for-supported-providers