### PR TITLE
priv: remove need for privileged container

### DIFF
--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -85,9 +85,7 @@ spec:
               name: providervol
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
-              mountPropagation: Bidirectional
-          securityContext:
-            privileged: true
+              mountPropagation: HostToContainer
       volumes:
         - name: providervol
           hostPath:

--- a/deploy/provider-gcp-plugin.yaml.tmpl
+++ b/deploy/provider-gcp-plugin.yaml.tmpl
@@ -85,9 +85,7 @@ spec:
               name: providervol
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
-              mountPropagation: Bidirectional
-          securityContext:
-            privileged: true
+              mountPropagation: HostToContainer
       volumes:
         - name: providervol
           hostPath:


### PR DESCRIPTION
The plugin does not create the mount, just interacts with mounts created by the CSI driver. `HostToContainer` is sufficient and does not require `privileged: true`.

Note: the pod still has permissions to create a token as any service account, so while it directly isnt `privileged` it could _create tokens_ for `privileged` Pods.