### PR TITLE
release prep: misc items for building a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to secrets-store-csi-driver-provider-gcp will be documented in this file. This file is maintained by humans and is therefore subject to error.
 
-## [unreleased]
+## v0.1.0
 
 ### Breaking
 
@@ -15,13 +15,14 @@ These RBAC rules gave the CSI driver the necesssary permissions to perform
 workload ID auth. The introduction of the grpc interface will have the plugin
 `DaemonSet` perform these operations instead.
 
-Driver now requires v0.0.14 of the CSI driver with:
+Driver now requires v0.0.14+ of the CSI driver with:
 `--grpc-supported-providers=gcp;` set.
 
 ### Added
 
 * Set Usage Agent String [#31](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/31)
 * `DEBUG` environment variable [#40](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/40)
+* Support for `nodePublishSecretRef` authentication [#58](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/58)
 
 ### Changed
 

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:e8b491a72eb3f3337005565470972f41c52a8de47fc5266d6bf3e2a94d88df26
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:faaa2d2bb6b8c470f81a2f5735b2c920277d1a17673c324c20a0863fedc66cad
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -90,5 +90,9 @@ spec:
         - name: providervol
           hostPath:
               path: /etc/kubernetes/secrets-store-csi-providers
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux

--- a/scripts/cloudbuild-release.yaml
+++ b/scripts/cloudbuild-release.yaml
@@ -23,14 +23,14 @@ options:
   machineType: N1_HIGHCPU_8
 steps:
 - name: 'gcr.io/cloud-builders/git'
-  args: ['clone', 'https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp']
+  args: ['clone', '--depth', '1', '--branch', '$TAG_NAME', https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp']
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build',
           '--build-arg',
           'VERSION=$TAG_NAME',
-          '-t', 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
-          '-t', 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
-          '-t', 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin',
+          '-t', 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$TAG_NAME',
+          '-t', 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$TAG_NAME',
+          '-t', 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$TAG_NAME',
           'secrets-store-csi-driver-provider-gcp' ]
 images:
 - 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'


### PR DESCRIPTION
Considering tagging a v0.1.0 release & build.

One circular dependency is that scripts/cloudbuild-release.yaml. I current have it requiring a branch to be tagged before building the image, but also it would be nice that if you check out the repo at a specific tag, `deploy/provider-gcp-plugin.yaml` would install that version.