### PR TITLE
v0.1.0: update yaml to new image sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 
 ## v0.1.0
 
+Images:
+* asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.1.0
+* europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.1.0
+* us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.1.0
+
+Digest: `sha256:625419e2104639f16b45a068c05a1da3d9bb9e714a3f3486b0fb11628580b7c8`
+
 ### Breaking
 
 If you were using a previous version, note that the following resources have

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:faaa2d2bb6b8c470f81a2f5735b2c920277d1a17673c324c20a0863fedc66cad
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:625419e2104639f16b45a068c05a1da3d9bb9e714a3f3486b0fb11628580b7c8
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
Release built from:

https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/commit/4722ffa0af341b799fcd26e3c8974da833d482a1