### PR TITLE
scripts: install and uninstall helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,25 +38,18 @@ following the [REST][rest] or [GRPC][grpc] documentation).
 
 ## Install
 
-NOTE: Follow direction at commit
-[8929e57](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/tree/8929e57f988dc87840d13c35235f5889d11c8005)
-to try out the driver.
-
 * Create a new GKE cluster with K8S 1.16+
-* Install [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) v0.0.14 or higher to
-the cluster.  You must also edit `deploy/csidriver.yaml` to set `--grpc-supported-providers=gcp;`.
+* Use the provided script to install both the
+  [Secret Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver)
+  and the GCP Plugin:
+
 ```shell
-$ kubectl apply -f deploy/rbac-secretproviderclass.yaml
-$ kubectl apply -f deploy/rbac-secretprovidersyncing.yaml
-$ kubectl apply -f deploy/csidriver.yaml
-$ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
-$ kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
-$ kubectl apply -f deploy/secrets-store-csi-driver.yaml
+$ scripts/install-driver.sh
 ```
-* Install the plugin DaemonSet & additional RoleBindings
-```shell
-$ kubectl apply -f deploy/provider-gcp-plugin.yaml
-```
+
+The install script will install the driver and plugin to the `kube-system`
+namespace and enables all driver features like secret syncing and polling for
+new secret values.
 
 ## Build and deploy notes
 

--- a/scripts/install-driver.sh
+++ b/scripts/install-driver.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will install CSI driver with all features enabled into kube-system.
+
+set -o errexit  # Exit with error on non-zero exit codes
+set -o pipefail # Check the exit code of *all* commands in a pipeline
+set -o nounset  # Error if accessing an unbound variable
+set -x          # Print each command as it is run
+
+SECRET_STORE_VERSION=v0.0.16
+GCP_PROVIDER_SHA=v0.1.0
+
+# -- CSI Driver Info --
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/csidriver.yaml
+
+# -- CRD --
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+
+# -- RBAC --
+# namespace: default => namespace: kube-system
+curl -s https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/rbac-secretproviderclass.yaml  2>&1 |
+    sed "s/namespace: default/namespace: kube-system/g;" |
+    kubectl apply -f -
+
+curl -s https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/rbac-secretprovidersyncing.yaml  2>&1 |
+    sed "s/namespace: default/namespace: kube-system/g;" |
+    kubectl apply -f -
+
+# -- DaemonSet --
+# namespace: default => namespace: kube-system
+# set "--grpcSupportedProviders=gcp;"
+curl -s https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/secrets-store-csi-driver.yaml  2>&1 |
+    awk '/rotation-poll-interval/ && !x {print "            - \"--grpc-supported-providers=gcp;\""; x=1} 1' |
+    sed "s/--enable-secret-rotation=false/--enable-secret-rotation=true/g;" |
+    kubectl apply -n kube-system -f -
+
+# -- GCP Plugin --
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/$GCP_PROVIDER_SHA/deploy/provider-gcp-plugin.yaml

--- a/scripts/install-driver.sh
+++ b/scripts/install-driver.sh
@@ -21,8 +21,8 @@ set -o pipefail # Check the exit code of *all* commands in a pipeline
 set -o nounset  # Error if accessing an unbound variable
 set -x          # Print each command as it is run
 
-SECRET_STORE_VERSION=v0.0.16
-GCP_PROVIDER_SHA=v0.1.0
+SECRET_STORE_VERSION=v0.0.17
+GCP_PROVIDER_SHA=v0.2.0
 
 # -- CSI Driver Info --
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/csidriver.yaml
@@ -43,9 +43,7 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driv
 
 # -- DaemonSet --
 # namespace: default => namespace: kube-system
-# set "--grpcSupportedProviders=gcp;"
 curl -s https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/deploy/secrets-store-csi-driver.yaml  2>&1 |
-    awk '/rotation-poll-interval/ && !x {print "            - \"--grpc-supported-providers=gcp;\""; x=1} 1' |
     sed "s/--enable-secret-rotation=false/--enable-secret-rotation=true/g;" |
     kubectl apply -n kube-system -f -
 

--- a/scripts/uninstall-driver.sh
+++ b/scripts/uninstall-driver.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit  # Exit with error on non-zero exit codes
+set -o pipefail # Check the exit code of *all* commands in a pipeline
+set -o nounset  # Error if accessing an unbound variable
+set -x          # Print each command as it is run
+
+# Uninstall plugin
+kubectl delete ds csi-secrets-store-provider-gcp -n kube-system
+kubectl delete clusterrolebinding secrets-store-csi-driver-provider-gcp-rolebinding
+kubectl delete sa secrets-store-csi-driver-provider-gcp -n kube-system
+kubectl delete clusterrole secrets-store-csi-driver-provider-gcp-role
+
+# Uninstall CSI Driver
+kubectl delete ds csi-secrets-store-provider -n kube-system
+
+kubectl delete clusterrolebinding secretproviderclasses-rolebinding
+kubectl delete clusterrole secretproviderclasses-role
+
+kubectl delete clusterrolebinding secretprovidersyncing-rolebinding
+kubectl delete clusterrole secretprovidersyncing-role
+
+kubectl delete sa secrets-store-csi-driver -n kube-system
+
+kubectl delete crd secretproviderclasses.secrets-store.csi.x-k8s.io
+kubectl delete crd secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io

--- a/scripts/uninstall-driver.sh
+++ b/scripts/uninstall-driver.sh
@@ -26,7 +26,7 @@ kubectl delete sa secrets-store-csi-driver-provider-gcp -n kube-system
 kubectl delete clusterrole secrets-store-csi-driver-provider-gcp-role
 
 # Uninstall CSI Driver
-kubectl delete ds csi-secrets-store-provider -n kube-system
+kubectl delete ds csi-secrets-store -n kube-system
 
 kubectl delete clusterrolebinding secretproviderclasses-rolebinding
 kubectl delete clusterrole secretproviderclasses-role
@@ -38,3 +38,5 @@ kubectl delete sa secrets-store-csi-driver -n kube-system
 
 kubectl delete crd secretproviderclasses.secrets-store.csi.x-k8s.io
 kubectl delete crd secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
+
+kubectl delete csidriver secrets-store.csi.k8s.io


### PR DESCRIPTION
Simplify install by providing a helper script.

The current upstream YAMLs require some changes for working well with the plugin:
* `gcp` must be included in `--grpc-supported-providers`
* `kube-system` namespace for best practices

Instead of requiring helm or vendoring these files, just provide a script to pull them and make needed modifications before applying to the cluster.