### PR TITLE
main: cleanup socket before attempting to listen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to secrets-store-csi-driver-provider-gcp will be documented in this file. This file is maintained by humans and is therefore subject to error.
 
+## v0.1.1 (unreleased)
+
+### Fixed
+
+* Cleanup unix domain socket
+
 ## v0.1.0
 
 Images:

--- a/main.go
+++ b/main.go
@@ -52,7 +52,12 @@ func main() {
 		Kubeconfig: *kubeconfig,
 	}
 
-	l, err := net.Listen("unix", filepath.Join(os.Getenv("TARGET_DIR"), "gcp.sock"))
+	socketPath := filepath.Join(os.Getenv("TARGET_DIR"), "gcp.sock")
+	// Attempt to remove the UDS to handle cases where a previous execution was
+	// killed before fully closing the socket listener and unlinking.
+	_ = os.Remove(socketPath)
+
+	l, err := net.Listen("unix", socketPath)
 	if err != nil {
 		log.Fatalf("Unable to listen to unix socket: %s", err)
 	}


### PR DESCRIPTION
Observed some errors:

```
2020/10/21 23:51:40 Unable to listen to unix socket: listen unix /etc/kubernetes/secrets-store-csi-providers/gcp.sock: bind: address already in use
```