### PR TITLE
test: update e2e tests to use v0.0.18

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as build-env
+FROM golang:1.15 as build-env
 ENV CGO_ENABLED=0 \
     GOOS=linux \
     GOARCH=amd64
@@ -25,9 +25,8 @@ RUN mv kubectl /bin/
 
 WORKDIR /test/deploy
 
-# TODO: Change this production yaml when https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/351 makes it into the secrets-store-csi-driver release
-# secrets-store-csi-driver
 RUN curl -fLO https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/manifest_staging/deploy/rbac-secretproviderclass.yaml
+RUN curl -fLO https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/manifest_staging/deploy/rbac-secretprovidersyncing.yaml
 RUN curl -fLO https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/manifest_staging/deploy/csidriver.yaml
 RUN curl -fLO https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 RUN curl -fLO https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/$SECRET_STORE_VERSION/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -115,8 +115,9 @@ func setupTestSuite() {
 	check(execCmd(gcloudCmd))
 
 	// Install Secret Store
-	check(execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile, "--namespace", "default",
+	check(execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile,
 		"-f", "deploy/rbac-secretproviderclass.yaml",
+		"-f", "deploy/rbac-secretprovidersyncing.yaml",
 		"-f", "deploy/csidriver.yaml",
 		"-f", "deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml",
 		"-f", "deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml",
@@ -124,7 +125,7 @@ func setupTestSuite() {
 	)))
 
 	// Install GCP Plugin and Workload Identity bindings
-	check(execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile, "--namespace", "kube-system",
+	check(execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile,
 		"-f", pluginFile)))
 
 	// Create test secret

--- a/test/infra/prow/presubmit.sh
+++ b/test/infra/prow/presubmit.sh
@@ -21,7 +21,7 @@ set -x          # Print each command as it is run
 
 export CLUSTER_NAME=management-cluster
 export PROJECT_ID=secretmanager-csi-build
-export SECRET_STORE_VERSION=ad965e92d14a87ad88f7f61c764afaede1ff6107
+export SECRET_STORE_VERSION=v0.0.18
 
 # Populated by prow pod utilities
 # https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md#pod-utilities


### PR DESCRIPTION
v0.0.18 includes necessary grpc flags, and installs to kube-system so we should test against that.

Also install the `rbac-secretprovidersyncing.yaml` bindings for future tests of the k8s syncing feature.