### PR TITLE
workload-id: bind test-pods/default to prow-pod-utils@

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/prow-pod-utils-sa-iam-policy.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/prow-pod-utils-sa-iam-policy.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: prow-pod-utils-sa-iam-policy
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: prow-pod-utils-sa
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - serviceAccount:secretmanager-csi-build.svc.id.goog[test-pods/prow-test-sa]

--- a/test/infra/anthos-managed/namespaces/test-pods/prow-test-sa.yaml
+++ b/test/infra/anthos-managed/namespaces/test-pods/prow-test-sa.yaml
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prow-test-sa
+  annotations:
+    iam.gke.io/gcp-service-account: prow-pod-utils@secretmanager-csi-build.iam.gserviceaccount.com


### PR DESCRIPTION
after this is running a PR will be made to remove `GOOGLE_APPLICATION_CREDENTIALS` from 

https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml

https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/72