### PR TITLE
pprof: add an option to enable pprof profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Digest: `TODO`
 * Initial prometheus metrics collection [#85](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/85)
 * `livenessProbe` [#85](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/85)
 * [Debugging documentation](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/v0.3.0/docs/debugging.md) [#85](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/85)
+* Optional pprof debugging endpoint [#88](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/88)
 
 ## v0.2.0
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -126,6 +126,16 @@ kubectl port-forward csi-secrets-store-provider-gcp-vmqct --namespace=kube-syste
 curl localhost:8095/metrics
 ```
 
+## pprof
+
+Starting the plugin with `-enable-pprof=true` will enable a debug http endpoint
+at `-debug_addr`.  Accessing this will also require `port-forward`:
+
+```cli
+kubectl port-forward csi-secrets-store-provider-gcp-vmqct --namespace=kube-system 6060:6060
+curl localhost:6060/debug/pprof
+```
+
 ## Objects
 
 View `SecretProviderClass`s:


### PR DESCRIPTION
while performing some load tests https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/32 this was useful (specifically `debug/pprof/trace?seconds=5`) to find slowdowns. (I found that the k8s client has a default built in rate limiter).