### PR TITLE
v0.3.0: update yaml to new image sha and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to secrets-store-csi-driver-provider-gcp will be documented in this file. This file is maintained by humans and is therefore subject to error.
 
-## unreleased (v0.3.0)
+## unreleased (v0.4.0)
+
+## v0.3.0
 
 Images:
 
-* TODO
+* `asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.3.0`
+* `europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.3.0`
+* `us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.3.0`
 
-Digest: `TODO`
+Digest: `sha256:90eeaef1afcbac988fb9f5a96222dff91f79920e9fa1c0d4200688ebc2680622`
 
 ### Changed
 

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:214f7aec249aaf450106eddd4455221f84283e8df2751ef5c70b6b1a69e598a0
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:90eeaef1afcbac988fb9f5a96222dff91f79920e9fa1c0d4200688ebc2680622
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -87,6 +87,14 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /live
+              port: 8095
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
       volumes:
         - name: providervol
           hostPath:

--- a/deploy/provider-gcp-plugin.yaml.tmpl
+++ b/deploy/provider-gcp-plugin.yaml.tmpl
@@ -71,7 +71,6 @@ spec:
         - name: provider
           image: gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp:$GCP_PROVIDER_SHA
           args:
-          - "-metrics_addr=:8095"
           - "-v=5"
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Built and tagged images off of `release-0.3` at commit `c801110c2d51e8fc58e74d9ee2a0eafaeda79cd2`.

Updating changelog shas and `deploy/provider-gcp-plugin.yaml` with the new image and liveness probe configuration.

After this is merged into `release-0.3` branch, it will be tagged as v0.3.0 and then merged into `main`