### PR TITLE
Use provided context for external calls

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -137,7 +137,7 @@ func tradeIDBindToken(ctx context.Context, k8sToken, idPool, idProvider string) 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/identitybindingtoken", bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://securetoken.googleapis.com/v1/identitybindingtoken", bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make use of the provided context introduced [here](https://github.com/christopherL91/secrets-store-csi-driver-provider-gcp/blob/main/auth/auth.go#L57) using [http.NewRequestWithContext](https://golang.org/pkg/net/http/#NewRequestWithContext) available since version `1.13`