### PR TITLE
v0.4.0: update deploy + changelog (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to secrets-store-csi-driver-provider-gcp will be documented in this file. This file is maintained by humans and is therefore subject to error.
 
-## unreleased (v0.4.0)
+## unreleased
+
+## v0.4.0
+
+Images:
+
+* `asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.4.0`
+* `europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.4.0`
+* `us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v0.4.0`
+
+Digest: `sha256:d4b3b361dbf41ae407532358ec89510a20fc15d6e9620fd27f281c1e8f6db864`
 
 ### Added
 

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:90eeaef1afcbac988fb9f5a96222dff91f79920e9fa1c0d4200688ebc2680622
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:d4b3b361dbf41ae407532358ec89510a20fc15d6e9620fd27f281c1e8f6db864
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ Notes on building a release.
     gcloud builds submit --config scripts/cloudbuild-release.yaml --substitutions=_VERSION=<vX.X.X>,_BRANCH_NAME=<release-X.X> --no-source
     ```
 
-4. Update `deploy/` `yaml` files to point to the content addressable sha
+4. Update `deploy/` `yaml` files to point to the content addressable sha and update `CHANGELOG.md`
 5. Manually test release image
 6. Tag the commit from step 4 as `vX.X.X` by creating a new release
 7. Merge changes from `release-X.X` into `main`


### PR DESCRIPTION
pull changes from `release-0.4` branch into `main`