### PR TITLE
testing: parameterize the gke version

### DIFF
--- a/test/e2e/e2e-test-job.yaml.tmpl
+++ b/test/e2e/e2e-test-job.yaml.tmpl
@@ -35,3 +35,5 @@ spec:
             value: "$PROJECT_ID"
           - name: SECRET_STORE_VERSION
             value: "$SECRET_STORE_VERSION"
+          - name: GKE_VERSION
+            value: "$GKE_VERSION"

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -38,6 +38,7 @@ type testFixture struct {
 	kubeconfigFile     string
 	testProjectID      string
 	secretStoreVersion string
+	gkeVersion         string
 }
 
 var f testFixture
@@ -74,6 +75,7 @@ func replaceTemplate(templateFile string, destFile string) error {
 	template = strings.ReplaceAll(template, "$TEST_SECRET_ID", f.testSecretID)
 	template = strings.ReplaceAll(template, "$GCP_PROVIDER_SHA", f.gcpProviderBranch)
 	template = strings.ReplaceAll(template, "$ZONE", zone)
+	template = strings.ReplaceAll(template, "$GKE_VERSION", f.gkeVersion)
 	return ioutil.WriteFile(destFile, []byte(template), 0644)
 }
 
@@ -93,6 +95,19 @@ func setupTestSuite() {
 	if len(f.secretStoreVersion) == 0 {
 		log.Println("SECRET_STORE_VERSION is empty, defaulting to 'master'")
 		f.secretStoreVersion = "master"
+	}
+	// Version of the GKE cluster to run the tests on
+	// spec.releaseChannel.channel from:
+	// https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containercluster
+	f.gkeVersion = os.Getenv("GKE_VERSION")
+	switch f.gkeVersion {
+	case "STABLE":
+	case "REGULAR":
+	case "RAPID":
+		break
+	default:
+		log.Printf("GKE_VERSION is invalid (%q), defaulting to 'STABLE'", f.gkeVersion)
+		f.gkeVersion = "STABLE"
 	}
 
 	tempDir, err := ioutil.TempDir("", "csi-tests")
@@ -202,4 +217,12 @@ func TestMountSecret(t *testing.T) {
 	if !bytes.Equal(stdout.Bytes(), []byte(f.testSecretID)) {
 		t.Fatalf("Secret value is %v, want: %v", stdout.String(), f.testSecretID)
 	}
+}
+
+func TestMountSyncSecret(t *testing.T) {
+	t.Skip("TODO: test secret sync")
+}
+
+func TestMountRotateSecret(t *testing.T) {
+	t.Skip("TODO: test rotate")
 }

--- a/test/e2e/templates/test-cluster.yaml.tmpl
+++ b/test/e2e/templates/test-cluster.yaml.tmpl
@@ -25,3 +25,5 @@ spec:
   monitoringService: monitoring.googleapis.com/kubernetes
   workloadIdentityConfig:
     identityNamespace: $PROJECT_ID.svc.id.goog
+  releaseChannel:
+    channel: $GKE_VERSION

--- a/test/e2e/templates/test-pod.yaml.tmpl
+++ b/test/e2e/templates/test-pod.yaml.tmpl
@@ -16,27 +16,6 @@ kind: ServiceAccount
 metadata:
   name: test-cluster-sa
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: configmap-admin
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: test-cluster-sa-configmap-admin
-subjects:
-  - kind: ServiceAccount
-    name: test-cluster-sa
-roleRef:
-  kind: Role
-  name: configmap-admin
-  apiGroup: rbac.authorization.k8s.io
----
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:

--- a/test/infra/prow/presubmit.sh
+++ b/test/infra/prow/presubmit.sh
@@ -21,7 +21,8 @@ set -x          # Print each command as it is run
 
 export CLUSTER_NAME=management-cluster
 export PROJECT_ID=secretmanager-csi-build
-export SECRET_STORE_VERSION=v0.0.18
+export SECRET_STORE_VERSION=${SECRET_STORE_VERSION:-v0.0.23}
+export GKE_VERSION=${GKE_VERSION:-STABLE}
 
 # Populated by prow pod utilities
 # https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md#pod-utilities
@@ -37,7 +38,7 @@ export JOB_NAME="e2e-test-job-$(head /dev/urandom | base64 | tr -dc 'a-z' | head
 
 # Start up E2E tests
 gcloud container clusters get-credentials $CLUSTER_NAME --zone us-central1-c --project $PROJECT_ID
-sed "s/\$GCP_PROVIDER_SHA/${GCP_PROVIDER_SHA}/g;s/\$PROJECT_ID/${PROJECT_ID}/g;s/\$JOB_NAME/${JOB_NAME}/g;s/\$SECRET_STORE_VERSION/${SECRET_STORE_VERSION}/g" \
+sed "s/\$GCP_PROVIDER_SHA/${GCP_PROVIDER_SHA}/g;s/\$PROJECT_ID/${PROJECT_ID}/g;s/\$JOB_NAME/${JOB_NAME}/g;s/\$SECRET_STORE_VERSION/${SECRET_STORE_VERSION}/g;s/\$GKE_VERSION/${GKE_VERSION}/g" \
     test/e2e/e2e-test-job.yaml.tmpl | kubectl apply -f -
 
 # Wait until job start, then subscribe to job logs


### PR DESCRIPTION
Allow testing against rapid/stable/regular update channels of gke.

These will be set in the oss-test-infra repo through envvars.

Also updates the default provider version for tests to v0.0.23