### PR TITLE
flags: default write_secrets to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ var (
 	metricsAddr   = flag.String("metrics_addr", ":8095", "configure http listener for reporting metrics")
 	enableProfile = flag.Bool("enable-pprof", false, "enable pprof profiling")
 	debugAddr     = flag.String("debug_addr", "localhost:6060", "port for pprof profiling")
-	writeSecrets  = flag.Bool("write_secrets", true, "whether to write the secrets directly to the filesystem (true) or returns secrets in grpc response to the driver (false, requires driver v0.0.21+)")
+	writeSecrets  = flag.Bool("write_secrets", false, "whether to write the secrets directly to the filesystem (true) or returns secrets in grpc response to the driver (false, requires driver v0.0.21+)")
 
 	version = "dev"
 )

--- a/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
@@ -86,9 +86,6 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -101,9 +98,5 @@ spec:
         - name: providervol
           hostPath:
               path: /etc/kubernetes/secrets-store-csi-providers
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
-            type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Next step of https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/98 - default to returning files for the driver to write.

Requires driver v0.0.21 or greater (prefer v0.0.22+ for atomic file writing).

A future release will deprecate the flag, remove all file writing logic from the gcp plugin, and remove the host paths.