### PR TITLE
logging: default log the auth type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 ### Changed
 
 * The `-write_secrets` flag defaults to `false`. This requires `v0.0.21+` of the `secrets-store-csi-driver`. [#98](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/98)
+* `wrote secret` and `added secret to response` log messages moved to level 5 (viewable by setting `-v=5`). [https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/120](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/120)
 
 ### Added
 

--- a/config/config.go
+++ b/config/config.go
@@ -115,13 +115,13 @@ func Parse(in *MountParams) (*MountConfig, error) {
 	switch attrib["auth"] {
 	case "provider-adc":
 		if out.AuthNodePublishSecret {
-			klog.InfoS("attempting to set both nodePublishSecretRef and provider-adc auth. For details consult https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/authentication.md", podInfo)
+			klog.InfoS("attempting to set both nodePublishSecretRef and provider-adc auth. For details consult https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/authentication.md", "pod", podInfo)
 			return nil, fmt.Errorf("attempting to set both nodePublishSecretRef and provider-adc auth")
 		}
 		out.AuthProviderADC = true
 	case "pod-adc":
 		if out.AuthNodePublishSecret {
-			klog.InfoS("attempting to set both nodePublishSecretRef and pod-adc auth. For details consult https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/authentication.md", podInfo)
+			klog.InfoS("attempting to set both nodePublishSecretRef and pod-adc auth. For details consult https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/authentication.md", "pod", podInfo)
 			return nil, fmt.Errorf("attempting to set both nodePublishSecretRef and pod-adc auth")
 		}
 		out.AuthPodADC = true
@@ -129,8 +129,18 @@ func Parse(in *MountParams) (*MountConfig, error) {
 		// default to pod auth unless nodePublishSecret is set
 		out.AuthPodADC = !out.AuthNodePublishSecret
 	default:
-		klog.InfoS("unknown auth configuration", podInfo)
+		klog.InfoS("unknown auth configuration", "pod", podInfo)
 		return nil, fmt.Errorf("unknown auth configuration: %q", attrib["auth"])
+	}
+
+	if out.AuthNodePublishSecret {
+		klog.InfoS("parsed auth", "auth", "nodePublishSecretRef", "pod", podInfo)
+	}
+	if out.AuthPodADC {
+		klog.InfoS("parsed auth", "auth", "pod-adc", "pod", podInfo)
+	}
+	if out.AuthProviderADC {
+		klog.InfoS("parsed auth", "auth", "provider-adc", "pod", podInfo)
 	}
 
 	if os.Getenv("DEBUG") == "true" {

--- a/server/server.go
+++ b/server/server.go
@@ -146,14 +146,14 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, cfg *co
 				return nil, status.Error(codes.Internal, fmt.Sprintf("failed to write %s at %s: %s", secret.ResourceName, cfg.TargetPath, err))
 			}
 
-			klog.InfoS("wrote secret", "secret", secret.ResourceName, "path", cfg.TargetPath, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
+			klog.V(5).InfoS("wrote secret", "secret", secret.ResourceName, "path", cfg.TargetPath, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
 		} else {
 			out.Files = append(out.Files, &v1alpha1.File{
 				Path:     secret.FileName,
 				Mode:     int32(cfg.Permissions),
 				Contents: result.Payload.Data,
 			})
-			klog.InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
+			klog.V(5).InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
 		}
 
 		ovs[i] = &v1alpha1.ObjectVersion{


### PR DESCRIPTION
Include the configured auth type in logs by default to assist when permission denied errors occur.

Currently permission denied errors look like:

```
{"ts":1624909602038.1943,"msg":"response","v":5,"method":"/v1alpha1.CSIDriverProvider/Mount","deadline":"1m59.997834354s","duration":"142.792351ms","status.code":"Internal","status.message":"rpc error: code = PermissionDenied desc = Permission 'secretmanager.versions.access' denied for resource 'REDACTED' (or it may not exist).,rpc error: code = PermissionDenied desc = Permission 'secretmanager.versions.access' denied for resource 'REDACTED' (or it may not exist)."}
```

Which does not include the calling principal which can make it difficult to debug. This change will at least add log lines like:

```
{"ts":1625074179555.4895,"msg":"parsed auth","v":0,"auth":"pod-adc","pod":"default/mypod"}
```