### PR TITLE
write_secrets: remove option to write secrets directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 
 ## unreleased
 
+### Removed
+
+* The `-write_secrets` flag has been removed. All writes to the pod filesystem will now be done by the CSI driver
+  instead of this plugin. This requires `v0.0.21+` of the `secrets-store-csi-driver`. [#98](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/98)
+
 ## v0.5.0
 
 Images:

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ var (
 	metricsAddr   = flag.String("metrics_addr", ":8095", "configure http listener for reporting metrics")
 	enableProfile = flag.Bool("enable-pprof", false, "enable pprof profiling")
 	debugAddr     = flag.String("debug_addr", "localhost:6060", "port for pprof profiling")
-	writeSecrets  = flag.Bool("write_secrets", false, "whether to write the secrets directly to the filesystem (true) or returns secrets in grpc response to the driver (false, requires driver v0.0.21+)")
+	_             = flag.Bool("write_secrets", false, "[unused]")
 
 	version = "dev"
 )
@@ -90,9 +90,8 @@ func main() {
 
 	// setup provider grpc server
 	s := &server.Server{
-		UA:           ua,
-		KubeClient:   clientset,
-		WriteSecrets: *writeSecrets,
+		UA:         ua,
+		KubeClient: clientset,
 	}
 
 	socketPath := filepath.Join(os.Getenv("TARGET_DIR"), "gcp.sock")


### PR DESCRIPTION
Remove the `-write_secrets` entirely from the next release.

Integration tests have been running with the flag and `test/e2e/templates/provider-gcp-plugin.yaml.tmpl` has been running with the mount removed from pod.

Removing the mount will be done separately so that users who kubectl apply `deploy/provider-gcp-plugin.yaml` won't get a half-released yaml.

Resolves most of #98 excluding the `yaml` update which will be done in #124