### PR TITLE
write_secrets: remove host volume mount

### DIFF
--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -84,9 +84,6 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -99,9 +96,5 @@ spec:
         - name: providervol
           hostPath:
               path: /etc/kubernetes/secrets-store-csi-providers
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
-            type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Starting in 0.6.0 only write secrets through the grpc interface

Closes out https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/98