### PR TITLE
feat: re-use secretmanager client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 
 ## unreleased
 
+### Added
+
+* `-sm_connection_pool_size` flag added with default value of `5`. Added as part of an optimization to reuse the same Secret Manager client across all `Mount` operations. [#94](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/94)
+
 ### Removed
 
 * The `-write_secrets` flag has been removed. All writes to the pod filesystem will now be done by the CSI driver

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.68.0
 	github.com/google/go-cmp v0.5.4
+	github.com/googleapis/gax-go/v2 v2.0.5
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.16.0
 	go.opentelemetry.io/otel/exporters/metric/prometheus v0.16.0
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43


### PR DESCRIPTION
Addresses #94

Creates the SM client once in `main` backed by a pool of  (currently) 5 underlying connection. On `Mount` requests then add Per RPC auth with the correct tokensource.
