### PR TITLE
tests: configure secret and ACLs for k8s prow syncing

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
@@ -28,6 +28,33 @@ spec:
   replication:
     automatic: true
 ---
+# This secret will hold the exported service account credential for the
+# identity:
+#
+#    k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
+#
+# This exported SA cred will then be injected and used by the
+# https://github.com/kubernetes-sigs/secrets-store-csi-driver
+# test cases.
+#
+# This should be rotated with:
+#
+#   $ gcloud iam service-accounts keys create "key.json" \
+#     --project="secretmanager-csi-build" \
+#     --iam-account="k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com"
+#
+#   $ gcloud secrets versions add k8s-oss-prow --project=secretmanager-csi-build --data-file=key.json
+#
+apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+kind: SecretManagerSecret
+metadata:
+  name: k8s-oss-prow
+  labels:
+    replication-type: automatic
+spec:
+  replication:
+    automatic: true
+---
   apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
   kind: SecretManagerSecretVersion
   metadata:
@@ -53,3 +80,22 @@ spec:
     - role: roles/secretmanager.secretAccessor
       members:
         - serviceAccount:k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
+---
+# See
+# https://github.com/kubernetes/test-infra/blob/master/prow/prow_secrets.md#prow-secrets-management
+# and
+# https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+# for information on secret syncing.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: k8s-oss-prow-binding
+spec:
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    name: k8s-oss-prow
+  bindings:
+    - role: roles/secretmanager.secretAccessor
+      members:
+        - serviceAccount:kubernetes-external-secrets-sa@k8s-prow-builds.iam.gserviceaccount.com


### PR DESCRIPTION
Declare a GCP secret to hold an exported SA credential for the:

`k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com`  identity

This is then sync'd to the https://github.com/kubernetes/test-infra prow instance as `gcp-secrets-store-cred` K8s secret and injected into the https://github.com/kubernetes-sigs/secrets-store-csi-driver integration tests as [`GCP_SA_JSON`](https://github.com/kubernetes/test-infra/blob/2e9846ac845543cdb68a5f3b3faca52653597e3d/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml#L30-L37).

Once available there, it is [passed to this provider](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/7cef422aeae158f3cd8ccb6f1be3e60ba82cdcd4/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml#L19-L26) as a [`nodePublishSecretRef`](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/authentication.md#nodepublishsecretref).

This is needed because the integration test needs to read an actual secret from GCP Secret Manager, and needs an identity to authorize. The only way to give a prow test pod an identity is an exported SA credential.