### PR TITLE
test: remove sync secret for prow jobs

### DIFF
--- a/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
+++ b/test/infra/anthos-managed/namespaces/secretmanager-csi-build/integration-test-resources.yaml
@@ -16,7 +16,8 @@ kind: IAMServiceAccount
 metadata:
   name: k8s-csi-test
 spec:
-  displayName: Integration Tests Service Account
+  displayName: Prow Integration Tests Service Account
+  description: The Identity for secrets-store-csi-driver-e2e-gcp test cases in https://github.com/kubernetes/test-infra
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicy
@@ -28,6 +29,9 @@ spec:
     kind: IAMServiceAccount
     name: k8s-csi-test
   bindings:
+    # The secrets-store-csi-driver-e2e-gcp test cases in
+    # https://github.com/kubernetes/test-infra will use workload identity to
+    # Act As serviceAccount:k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
     - role: roles/iam.workloadIdentityUser
       members:
         - serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/secrets-store-csi-driver-gcp]
@@ -36,33 +40,6 @@ apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
 kind: SecretManagerSecret
 metadata:
   name: test-secret-a
-  labels:
-    replication-type: automatic
-spec:
-  replication:
-    automatic: true
----
-# This secret will hold the exported service account credential for the
-# identity:
-#
-#    k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
-#
-# This exported SA cred will then be injected and used by the
-# https://github.com/kubernetes-sigs/secrets-store-csi-driver
-# test cases.
-#
-# This should be rotated with:
-#
-#   $ gcloud iam service-accounts keys create "key.json" \
-#     --project="secretmanager-csi-build" \
-#     --iam-account="k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com"
-#
-#   $ gcloud secrets versions add k8s-oss-prow --project=secretmanager-csi-build --data-file=key.json
-#
-apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
-kind: SecretManagerSecret
-metadata:
-  name: k8s-oss-prow
   labels:
     replication-type: automatic
 spec:
@@ -94,25 +71,3 @@ spec:
     - role: roles/secretmanager.secretAccessor
       members:
         - serviceAccount:k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
-        # TODO: remove once https://github.com/kubernetes/test-infra/pull/22944
-        # is merged and switches workload identity to the k8s-csi-test SA.
-        - serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/default]
----
-# See
-# https://github.com/kubernetes/test-infra/blob/master/prow/prow_secrets.md#prow-secrets-management
-# and
-# https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
-# for information on secret syncing.
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicy
-metadata:
-  name: k8s-oss-prow-binding
-spec:
-  resourceRef:
-    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
-    kind: SecretManagerSecret
-    name: k8s-oss-prow
-  bindings:
-    - role: roles/secretmanager.secretAccessor
-      members:
-        - serviceAccount:kubernetes-external-secrets-sa@k8s-prow-builds.iam.gserviceaccount.com


### PR DESCRIPTION
The driver project now uses workload identity to act as the k8s-csi-test
service account in prow job/integration tests.

This removes the need to export a k8s-csi-test service account credential
and write to secret manager and sync that secret to prow.

Block on https://github.com/kubernetes-sigs/secrets-store-csi-driver being [fixed](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver-presubmit#pr-secrets-store-csi-driver-e2e-gcp)