### PR TITLE
feat: allow nested paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 ### Added
 
 * `-sm_connection_pool_size` and `-iam_connection_pool_size` flags added with default value of `5`. Added as part of an optimization to reuse the same Secret Manager client across all `Mount` operations. [#94](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/94)
+* Secrets can now be written to nested paths. The `path` parameter is also added as an alias for `fileName` in the `SecretProviderClass`. [#125](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/125)
 
 ### Removed
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -258,57 +258,6 @@ func TestParseErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "fileName with path",
-			in: &MountParams{
-				Attributes: `
-				{
-					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"../good1.txt\"\n",
-					"csi.storage.k8s.io/pod.namespace": "default",
-					"csi.storage.k8s.io/pod.name": "mypod",
-					"csi.storage.k8s.io/pod.uid": "123",
-					"csi.storage.k8s.io/serviceAccount.name": "mysa"
-				}
-				`,
-				KubeSecrets: "{}",
-				TargetPath:  "/tmp/foo",
-				Permissions: 777,
-			},
-		},
-		{
-			name: "fileName with filename separator",
-			in: &MountParams{
-				Attributes: `
-				{
-					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"a:good1.txt\"\n",
-					"csi.storage.k8s.io/pod.namespace": "default",
-					"csi.storage.k8s.io/pod.name": "mypod",
-					"csi.storage.k8s.io/pod.uid": "123",
-					"csi.storage.k8s.io/serviceAccount.name": "mysa"
-				}
-				`,
-				KubeSecrets: "{}",
-				TargetPath:  "/tmp/foo",
-				Permissions: 777,
-			},
-		},
-		{
-			name: "fileName with path separator",
-			in: &MountParams{
-				Attributes: `
-				{
-					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"a/good1.txt\"\n",
-					"csi.storage.k8s.io/pod.namespace": "default",
-					"csi.storage.k8s.io/pod.name": "mypod",
-					"csi.storage.k8s.io/pod.uid": "123",
-					"csi.storage.k8s.io/serviceAccount.name": "mysa"
-				}
-				`,
-				KubeSecrets: "{}",
-				TargetPath:  "/tmp/foo",
-				Permissions: 777,
-			},
-		},
-		{
 			name: "both nodePublishSecretRef and provider-adc",
 			in: &MountParams{
 				Attributes: `

--- a/server/server.go
+++ b/server/server.go
@@ -141,7 +141,7 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 	for i, secret := range cfg.Secrets {
 		result := results[i]
 		out.Files = append(out.Files, &v1alpha1.File{
-			Path:     secret.FileName,
+			Path:     secret.PathString(),
 			Mode:     int32(cfg.Permissions),
 			Contents: result.Payload.Data,
 		})

--- a/test/e2e/templates/test-invalid.yaml.tmpl
+++ b/test/e2e/templates/test-invalid.yaml.tmpl
@@ -1,0 +1,57 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-cluster-sa
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: gcp-test-secrets-invalid
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/secrets/$TEST_SECRET_ID/versions/latest"
+        path: "my/invalid/../path/$TEST_SECRET_ID"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-invalid
+spec:
+  serviceAccountName: test-cluster-sa
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: test-secret-mounter
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: "/var/gcp-test-secrets"
+      name: gcp-test-secrets
+  volumes:
+  - name: gcp-test-secrets
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "gcp-test-secrets-invalid"

--- a/test/e2e/templates/test-nested.yaml.tmpl
+++ b/test/e2e/templates/test-nested.yaml.tmpl
@@ -1,0 +1,57 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-cluster-sa
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: gcp-test-secrets-nested
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/secrets/$TEST_SECRET_ID/versions/latest"
+        path: "my/nested/path/$TEST_SECRET_ID"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-nested
+spec:
+  serviceAccountName: test-cluster-sa
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: test-secret-mounter
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: "/var/gcp-test-secrets"
+      name: gcp-test-secrets
+  volumes:
+  - name: gcp-test-secrets
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "gcp-test-secrets-nested"


### PR DESCRIPTION
Resolved https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/125

The driver now contains the safety checks for path traversal vulnerabilities when writing files, so update the provider to take advantage of that.

I also introduced the option of using the word `path` instead of `fileName` is it is semantically more correct if a nested path is used.