### PR TITLE
cleanup: switch to CODEOWNERS (github) from OWNERS (prow)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tam7t @colinman

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,0 @@
-approvers:
-- tam7t
-- colinman
-- rlingutla
-
-reviewers:
-- tam7t
-- colinman
-- rlingutla


### PR DESCRIPTION
Remove `OWNERS` which was used by prow in favor of github's [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)