### PR TITLE
tests: scheduled e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    # run daily @ 14:30 UTC against the default branch (main)
+    - cron: "30 14 * * *"
 
 jobs:
   e2e-test:


### PR DESCRIPTION
The:

```
    environment:
      name: e2e-test
```

requires manual approvals to gate access to the `GCP_CREDENTIALS` secret.

It may be OK to remove the action environment protection with the following settings:

![image](https://user-images.githubusercontent.com/1523807/138778527-493f8d85-77ae-4586-b2de-00393dc229ab.png)

But need verification first. Also unclear whether 'environment' is even something that can be filtered on when setting up federated auth: https://github.com/google-github-actions/auth#setup

EDIT:  On further inspection, actions triggered from a fork PR [will never get access to secrets](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) so I think this means that we just cant run the e2e tests on outside contributions automatically (or prior to submission).