### PR TITLE
v1.0.0: update deploy + changelog (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 
 ## unreleased
 
+## v1.0.0
+
+Images:
+
+* `asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.0.0`
+* `europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.0.0`
+* `us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.0.0`
+
+Digest: `sha256:cb491d4af4776ac352aac415676918fa7cd4ef1671e71c579175ef3e2820af09`
+
+### Changed
+
+* No code changes. This release is corresponds with the `v1.0.0` release of the
+[secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v1.0.0).
+* The deploy yaml no longer includes the `/var/lib/kubelet/pods` HostPath. This
+was needed when the plugin wrote the files to the pod filesystems but is not
+used since `v.0.5.0` set `-write_secrets=false`.
+
 ## v0.6.0
 
 Images:

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:2733764e6c008fd5d846f7e8a0795502acdc5c0997aac2effb66f39776386786
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:cb491d4af4776ac352aac415676918fa7cd4ef1671e71c579175ef3e2820af09
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -85,9 +85,6 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -100,9 +97,5 @@ spec:
         - name: providervol
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
-            type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Bring 1.0 changes into `main`, step 7 of https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/main/docs/releasing.md