### PR TITLE
chore: pin to v0 instead of master for gcloud action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       # TODO: replace with https://github.com/google-github-actions/auth and
       # workload identity instead of an exported SA credential.
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: "secretmanager-csi-build"
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
Address warning:

```
Warning: google-github-actions/setup-gcloud is pinned at HEAD. We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
```