### PR TITLE
chore: update tests to clear warnings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,11 +35,14 @@ jobs:
       - uses: actions/checkout@v2
       # TODO: replace with https://github.com/google-github-actions/auth and
       # workload identity instead of an exported SA credential.
+      - name: "Auth to GCP exist env"
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: "secretmanager-csi-build"
-          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-          export_default_credentials: true
+          install_components: 'gke-gcloud-auth-plugin'
       - name: Test
         run: |
           test/infra/runner.sh

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -12,6 +12,7 @@ RUN go test -c .
 # Use Cloud SDK image to use gCloud in tests
 ARG INSTALL_COMPONENTS=gke-gcloud-auth-plugin
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 COPY --from=build-env /tmp/secrets-store-csi-driver-provider-gcp/test/e2e/e2e.test /bin/
 COPY --from=build-env /tmp/secrets-store-csi-driver-provider-gcp/test/e2e/templates /test/templates

--- a/test/infra/runner.sh
+++ b/test/infra/runner.sh
@@ -24,6 +24,7 @@ export PROJECT_ID=secretmanager-csi-build
 export SECRET_STORE_VERSION=${SECRET_STORE_VERSION:-v1.0.0}
 export GKE_VERSION=${GKE_VERSION:-STABLE}
 export GCP_PROVIDER_SHA=${GITHUB_SHA:-main}
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 # Build the driver image
 gcloud builds submit --config scripts/cloudbuild-dev.yaml --substitutions=TAG_NAME=${GCP_PROVIDER_SHA} --project $PROJECT_ID


### PR DESCRIPTION
Clears the github action warning:

```
"service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization
```

and clears the gke / kubectl / gcloud warning:

```
CRITICAL: ACTION REQUIRED: gke-gcloud-auth-plugin, which is needed for continued use of kubectl, was not found or is not executable. Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```

The instructions on https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke were actually wrong, they said:

> you can revert to using the provider-specific code by setting export USE_GKE_GCLOUD_AUTH_PLUGIN=True

But you actually must set `USE_GKE_GCLOUD_AUTH_PLUGIN=True` in order to _use_ the plugin based credential retrieval, `False` would do the revert.