### PR TITLE
feat: add configuration for per secret file permission

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,10 @@ type Secret struct {
 
 	// Path is the relative path where the contents of the secret are written.
 	Path string `json:"path" yaml:"path"`
+
+	// Mode is the optional file mode for the file containing the secret. Must be
+	// an octal value between 0000 and 0777 or a decimal value between 0 and 511
+	Mode *int32 `json:"mode,omitempty" yaml:"mode,omitempty"`
 }
 
 // PodInfo includes details about the pod that is receiving the mount event.

--- a/server/server.go
+++ b/server/server.go
@@ -139,10 +139,15 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 	// Add secrets to response.
 	ovs := make([]*v1alpha1.ObjectVersion, len(cfg.Secrets))
 	for i, secret := range cfg.Secrets {
+		mode := int32(cfg.Permissions)
+		if secret.Mode != nil {
+			mode = *secret.Mode
+		}
+
 		result := results[i]
 		out.Files = append(out.Files, &v1alpha1.File{
 			Path:     secret.PathString(),
-			Mode:     int32(cfg.Permissions),
+			Mode:     mode,
 			Contents: result.Payload.Data,
 		})
 		klog.V(5).InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,11 +36,18 @@ import (
 )
 
 func TestHandleMountEvent(t *testing.T) {
+	secretFileMode := int32(0600) // decimal 384
+
 	cfg := &config.MountConfig{
 		Secrets: []*config.Secret{
 			{
 				ResourceName: "projects/project/secrets/test/versions/latest",
 				FileName:     "good1.txt",
+			},
+			{
+				ResourceName: "projects/project/secrets/test/versions/latest",
+				FileName:     "good2.txt",
+				Mode:         &secretFileMode,
 			},
 		},
 		Permissions: 777,
@@ -56,11 +63,20 @@ func TestHandleMountEvent(t *testing.T) {
 				Id:      "projects/project/secrets/test/versions/latest",
 				Version: "projects/project/secrets/test/versions/2",
 			},
+			{
+				Id:      "projects/project/secrets/test/versions/latest",
+				Version: "projects/project/secrets/test/versions/2",
+			},
 		},
 		Files: []*v1alpha1.File{
 			{
 				Path:     "good1.txt",
 				Mode:     777,
+				Contents: []byte("My Secret"),
+			},
+			{
+				Path:     "good2.txt",
+				Mode:     384, // octal 0600
 				Contents: []byte("My Secret"),
 			},
 		},

--- a/test/e2e/templates/test-mode.yaml.tmpl
+++ b/test/e2e/templates/test-mode.yaml.tmpl
@@ -1,0 +1,58 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-cluster-sa
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-test-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/secrets/$TEST_SECRET_ID/versions/latest"
+        path: "$TEST_SECRET_ID"
+        mode: 0400
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-mode
+spec:
+  serviceAccountName: test-cluster-sa
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: test-secret-mode
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: "/var/gcp-test-secrets"
+      name: gcp-test-secrets
+  volumes:
+  - name: gcp-test-secrets
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "gcp-test-secrets"


### PR DESCRIPTION
Allow user to define file permissions per secret with `mode` configuration option. Mode can be defined as octal or decimal value, e.g., `0400` or `256`.  If `mode` is not set for a secret continue to use `MountRequest.GetPermission()` as a default.

```yaml
apiVersion: secrets-store.csi.x-k8s.io/v1
kind: SecretProviderClass
metadata:
  name: gcp-test-secrets
spec:
  provider: gcp
  parameters:
    secrets: |
      - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
        path: "my-private-key.pem"
        mode: 0400
```


Related issue: https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/722

Precedent for `mode` as `*int32`: https://github.com/kubernetes/api/blob/79091dac6a32a1365edbc6de9576ffa74768a75c/core/v1/types.go#L1194


