### PR TITLE
Add helm charts to make it easier to change some values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ to access secrets stored in Secret Manager as files mounted in Kubernetes pods.
 
 ```shell
 kubectl apply -f deploy/provider-gcp-plugin.yaml
+# if you want to use helm
+# helm upgrade --install secrets-store-csi-driver-provider-gcp charts/secrets-store-csi-driver-provider-gcp
 ```
 
 NOTE: The driver's rotation and secret syncing functionality is still in Alpha and requires [additional installation

--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: secrets-store-csi-driver-provider-gcp
+description: A Helm chart to install Google Secret Manager Provider for Secret Store CSI Driver inside a Kubernetes cluster.
+type: application
+version: 0.1.0
+appVersion: "1.1.0"

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/_helpers.tpl
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.labels" -}}
+helm.sh/chart: {{ include "secrets-store-csi-driver-provider-gcp.chart" . }}
+{{ include "secrets-store-csi-driver-provider-gcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.selectorLabels" -}}
+app: {{ default "default" .Values.app }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.serviceAccountName" -}}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create the name of the daemon set to use
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.daemonSetName" -}}
+{{- default "default" .Values.app }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role to use
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.clusterRoleName" -}}
+{{- .Chart.Name }}-role
+{{- end }}
+
+{{/*
+Create the name of the cluster role binding to use
+*/}}
+{{- define "secrets-store-csi-driver-provider-gcp.clusterRoleBindingName" -}}
+{{- .Chart.Name }}-rolebinding
+{{- end }}

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrole.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-gcp.clusterRoleName" . }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-gcp.clusterRoleBindingName" . }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "secrets-store-csi-driver-provider-gcp.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
+    namespace: kube-system

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-gcp.daemonSetName" . }}
+  namespace: kube-system
+  labels:
+    {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "secrets-store-csi-driver-provider-gcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "secrets-store-csi-driver-provider-gcp.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
+      containers:
+        - name: provider
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /live
+              port: 8095
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: providervol
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
+  namespace: kube-system
+  labels:
+    {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -1,0 +1,29 @@
+nameOverride: ""
+
+serviceAccount:
+  annotations: {}
+  name: secrets-store-csi-driver-provider-gcp
+
+image:
+  repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
+  pullPolicy: IfNotPresent
+  hash: sha256:f7fd197984e95f777557ba9f6daef6c578f49bcddd1080fba0fe8f2c19fffd84
+
+app: csi-secrets-store-provider-gcp
+
+podAnnotations: {}
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 50m
+    memory: 100Mi
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## What?

Add helm charts for `provider-gcp-plugin`.

## Why?

When we want to add some properties to the manifest (`deploy/provider-gcp-plugin.yaml`), we needed to either way of the followings.

1. Copy the manifest file to our own repository and edit it.
2. `kubectl patch` after `kubectl apply deploy/provider-gcp-plugin.yaml`.

If we choose 1., we have to update the copied manifest, when the original in this repository updates. In the case of 2., we need some shell scripts to deploy. 

This PR makes it easy to deploy this plugin with some changes (like `taints` or `nodeSelector`).  

## Testing?

If this change seems acceptable, I will add some tests.

## Anything Else?

This is my first contribution to this repository, therefore I would really appreciate any feedback, suggestions and change requests.