### PR TITLE
fix: extend timeout and docker buildx push syntax

### DIFF
--- a/scripts/cloudbuild-dev.yaml
+++ b/scripts/cloudbuild-dev.yaml
@@ -15,7 +15,7 @@
 # Usage: from the root directory run:
 #
 # $ gcloud builds submit --config scripts/cloudbuild-dev.yaml
-timeout: 600s
+timeout: 1200s
 options:
   machineType: N1_HIGHCPU_8
 steps:
@@ -28,6 +28,5 @@ steps:
          'VERSION=$TAG_NAME',
          '-t',
          'gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp:$TAG_NAME',
+         '--push',
          '.']
-images:
-- 'gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp'

--- a/scripts/cloudbuild-release.yaml
+++ b/scripts/cloudbuild-release.yaml
@@ -18,7 +18,7 @@
 #
 # Requires permission for Cloud Build and the secretmanager-csi Artifact
 # Registry repos.
-timeout: 600s
+timeout: 1200s
 options:
   machineType: N1_HIGHCPU_8
 steps:
@@ -34,8 +34,5 @@ steps:
           '-t', 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$_VERSION',
           '-t', 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$_VERSION',
           '-t', 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:$_VERSION',
+          '--push',
           'secrets-store-csi-driver-provider-gcp' ]
-images:
-- 'us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'
-- 'europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'
-- 'asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin'


### PR DESCRIPTION
Fix the cloud build script from https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/193.

building arm64 requires extending the timeout and apparently the cloud build format for docker buildx pushes is different so adding the `--push` flag instead of using the `images` output in the yaml