### PR TITLE
v1.2.0: update deploy + changelog + helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to secrets-store-csi-driver-provider-gcp will be documented 
 
 ## unreleased
 
+## v1.2.0
+
+Images:
+
+* `asia-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.2.0`
+* `europe-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.2.0`
+* `us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.2.0`
+
+Digest: `sha256:b7dde5ed536b2c6500c9237e14f6851cf8a2ff6d7a72656c3741be38e2cddf4d`
+
+See CHANGELOG.md for more details.
+
+### Added
+
+* Per-secret file permissions [#182](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/182).
+* `arm64` multi-platform image [#193](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/193).
+* Fleet Workload Identity (Anthos Bare Metal) Support [#190](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/190) (read more at [docs/fleet-wif-notes.md](docs/fleet-wif-notes.md)).
+
+### Changed
+
+* Many dependencies updated and now built with go 1.20.
+
 ## v1.1.0
 
 Images:

--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -3,4 +3,4 @@ name: secrets-store-csi-driver-provider-gcp
 description: A Helm chart to install Google Secret Manager Provider for Secret Store CSI Driver inside a Kubernetes cluster.
 type: application
 version: 0.1.0
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -7,7 +7,7 @@ serviceAccount:
 image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
   pullPolicy: IfNotPresent
-  hash: sha256:f7fd197984e95f777557ba9f6daef6c578f49bcddd1080fba0fe8f2c19fffd84
+  hash: sha256:b7dde5ed536b2c6500c9237e14f6851cf8a2ff6d7a72656c3741be38e2cddf4d
 
 app: csi-secrets-store-provider-gcp
 

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
       containers:
         - name: provider
-          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:f7fd197984e95f777557ba9f6daef6c578f49bcddd1080fba0fe8f2c19fffd84
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:b7dde5ed536b2c6500c9237e14f6851cf8a2ff6d7a72656c3741be38e2cddf4d
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
Prep for v1.2.0 release,

See full list of changes at:

https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/compare/v1.1.0...d2834985815be4c62762ea281cc20a35ca9d428d