### PR TITLE
Have DaemonSet tolerate arm64 nodes

### DIFF
--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -97,5 +97,10 @@ spec:
         - name: providervol
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
+      tolerations:
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Since https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/193 the image is built to support amd64 and arm64

If you want to use arm64 nodes today (e.g., T2A nodes on GKE) you have to apply a [patch](https://github.com/wolfi-dev/wolfictl/blob/d1d33c7c57bf9e4d3e4090e824d43b7635dcb2d7/scripts/arm-patch.yaml) to make the GCP secrets-store provider work, which isn't well documented or discoverable, and will only trip people up.

This change makes the provider DaemonSet tolerate arm64 nodes by default, if they happen to be present.