### PR TITLE
Add AppArmor security profile to manage access and network communication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ to access secrets stored in Secret Manager as files mounted in Kubernetes pods.
 * Install the Google plugin DaemonSet & additional RoleBindings:
 
 ```shell
+kubectl apply -f deploy/apparmor-profile.yaml.tmpl
 kubectl apply -f deploy/provider-gcp-plugin.yaml
 # if you want to use helm
 # helm upgrade --install secrets-store-csi-driver-provider-gcp charts/secrets-store-csi-driver-provider-gcp

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/apparmor-profile.yaml.tmpl
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/apparmor-profile.yaml.tmpl
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apparmor-profiles
+  namespace: kube-system
+data:
+  k8s-secrets-store-csi-driver-provider-gcp: |-
+    #include <tunables/global>
+    profile k8s-secrets-store-csi-driver-provider-gcp flags=(attach_disconnected,mediate_deleted) {
+      #include <abstractions/base>
+
+      network inet tcp,
+      network inet udp,
+      network inet icmp,
+
+      deny network raw,
+
+      deny network packet,
+
+      file,
+      umount,
+
+      deny /bin/** wl,
+      deny /boot/** wl,
+      deny /dev/** wl,
+      deny /home/** wl,
+      deny /lib/** wl,
+      deny /lib64/** wl,
+      deny /media/** wl,
+      deny /mnt/** wl,
+      deny /opt/** wl,
+      deny /proc/** wl,
+      deny /root/** wl,
+      deny /sbin/** wl,
+      deny /srv/** wl,
+      deny /tmp/** wl,
+      deny /sys/** wl,
+      deny /usr/** wl,
+
+      audit /** w,
+
+      deny /bin/dash mrwklx,
+      deny /bin/sh mrwklx,
+      deny /usr/bin/top mrwklx,
+
+      capability chown,
+      capability dac_override,
+      capability setuid,
+      capability setgid,
+      capability net_bind_service,
+
+      deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+      deny @{PROC}/sysrq-trigger rwklx,
+      deny @{PROC}/mem rwklx,
+      deny @{PROC}/kmem rwklx,
+      deny @{PROC}/kcore rwklx,
+      deny mount,
+      deny /sys/[^f]*/** wklx,
+      deny /sys/f[^s]*/** wklx,
+      deny /sys/fs/[^c]*/** wklx,
+      deny /sys/fs/c[^g]*/** wklx,
+      deny /sys/fs/cg[^r]*/** wklx,
+      deny /sys/firmware/efi/efivars/** rwklx,
+      deny /sys/kernel/security/** rwklx,
+    }

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -33,6 +33,10 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
+            - name: profiles
+              mountPath: "/profiles"
+              readOnly: true
+              mountPropagation: None
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -45,6 +49,9 @@ spec:
         - name: providervol
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
+        - name: profiles
+          configMap:
+            name: apparmor-profiles
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/apparmor-profile.yaml.tmpl
+++ b/deploy/apparmor-profile.yaml.tmpl
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apparmor-profiles
+  namespace: kube-system
+data:
+  k8s-secrets-store-csi-driver-provider-gcp: |-
+    #include <tunables/global>
+    profile k8s-secrets-store-csi-driver-provider-gcp flags=(attach_disconnected,mediate_deleted) {
+      #include <abstractions/base>
+
+      network inet tcp,
+      network inet udp,
+      network inet icmp,
+
+      deny network raw,
+
+      deny network packet,
+
+      file,
+      umount,
+
+      deny /bin/** wl,
+      deny /boot/** wl,
+      deny /dev/** wl,
+      deny /home/** wl,
+      deny /lib/** wl,
+      deny /lib64/** wl,
+      deny /media/** wl,
+      deny /mnt/** wl,
+      deny /opt/** wl,
+      deny /proc/** wl,
+      deny /root/** wl,
+      deny /sbin/** wl,
+      deny /srv/** wl,
+      deny /tmp/** wl,
+      deny /sys/** wl,
+      deny /usr/** wl,
+
+      audit /** w,
+
+      deny /bin/dash mrwklx,
+      deny /bin/sh mrwklx,
+      deny /usr/bin/top mrwklx,
+
+      capability chown,
+      capability dac_override,
+      capability setuid,
+      capability setgid,
+      capability net_bind_service,
+
+      deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+      deny @{PROC}/sysrq-trigger rwklx,
+      deny @{PROC}/mem rwklx,
+      deny @{PROC}/kmem rwklx,
+      deny @{PROC}/kcore rwklx,
+      deny mount,
+      deny /sys/[^f]*/** wklx,
+      deny /sys/f[^s]*/** wklx,
+      deny /sys/fs/[^c]*/** wklx,
+      deny /sys/fs/c[^g]*/** wklx,
+      deny /sys/fs/cg[^r]*/** wklx,
+      deny /sys/firmware/efi/efivars/** rwklx,
+      deny /sys/kernel/security/** rwklx,
+    }

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -87,6 +87,8 @@ spec:
               name: providervol
             - name: profiles
               mountPath: "/profiles"
+              readOnly: true
+              mountPropagation: None
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -85,6 +85,8 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
+            - name: profiles
+              mountPath: "/profiles"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -97,6 +99,9 @@ spec:
         - name: providervol
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
+        - name: profiles
+          configMap:
+            name: apparmor-profiles
       tolerations:
         - key: kubernetes.io/arch
           operator: Equal

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,4 +21,6 @@ set -x          # Print each command as it is run
 
 TAG=$(git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD)
 
+kubectl apply -f test/e2e/templates/apparmor-profile.yaml.tmpl
+
 sed "s/\$PROJECT_ID/${PROJECT_ID}/g;s/\$GCP_PROVIDER_SHA/${TAG}/g" test/e2e/templates/provider-gcp-plugin.yaml.tmpl | kubectl apply -f -

--- a/test/e2e/templates/apparmor-profile.yaml.tmpl
+++ b/test/e2e/templates/apparmor-profile.yaml.tmpl
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apparmor-profiles
+  namespace: kube-system
+data:
+  k8s-secrets-store-csi-driver-provider-gcp: |-
+    #include <tunables/global>
+    profile k8s-secrets-store-csi-driver-provider-gcp flags=(attach_disconnected,mediate_deleted) {
+      #include <abstractions/base>
+
+      network inet tcp,
+      network inet udp,
+      network inet icmp,
+
+      deny network raw,
+
+      deny network packet,
+
+      file,
+      umount,
+
+      deny /bin/** wl,
+      deny /boot/** wl,
+      deny /dev/** wl,
+      deny /home/** wl,
+      deny /lib/** wl,
+      deny /lib64/** wl,
+      deny /media/** wl,
+      deny /mnt/** wl,
+      deny /opt/** wl,
+      deny /proc/** wl,
+      deny /root/** wl,
+      deny /sbin/** wl,
+      deny /srv/** wl,
+      deny /tmp/** wl,
+      deny /sys/** wl,
+      deny /usr/** wl,
+
+      audit /** w,
+
+      deny /bin/dash mrwklx,
+      deny /bin/sh mrwklx,
+      deny /usr/bin/top mrwklx,
+
+      capability chown,
+      capability dac_override,
+      capability setuid,
+      capability setgid,
+      capability net_bind_service,
+
+      deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+      deny @{PROC}/sysrq-trigger rwklx,
+      deny @{PROC}/mem rwklx,
+      deny @{PROC}/kmem rwklx,
+      deny @{PROC}/kcore rwklx,
+      deny mount,
+      deny /sys/[^f]*/** wklx,
+      deny /sys/f[^s]*/** wklx,
+      deny /sys/fs/[^c]*/** wklx,
+      deny /sys/fs/c[^g]*/** wklx,
+      deny /sys/fs/cg[^r]*/** wklx,
+      deny /sys/firmware/efi/efivars/** rwklx,
+      deny /sys/kernel/security/** rwklx,
+    }

--- a/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
@@ -108,6 +108,8 @@ spec:
             - mountPath: /var/run/secrets/tokens/gcp-ksa
               name: gcp-ksa
               readOnly: true
+            - name: profiles
+              mountPath: "/profiles"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -120,6 +122,9 @@ spec:
         - name: providervol
           hostPath:
               path: /etc/kubernetes/secrets-store-csi-providers
+        - name: profiles
+          configMap:
+            name: apparmor-profiles
         - name: gcp-ksa
           projected:
             defaultMode: 420

--- a/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
@@ -110,6 +110,8 @@ spec:
               readOnly: true
             - name: profiles
               mountPath: "/profiles"
+              readOnly: true
+              mountPropagation: None
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
@@ -88,6 +88,8 @@ spec:
               name: providervol
             - name: profiles
               mountPath: "/profiles"
+              readOnly: true
+              mountPropagation: None
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
@@ -86,6 +86,8 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
+            - name: profiles
+              mountPath: "/profiles"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -98,5 +100,8 @@ spec:
         - name: providervol
           hostPath:
               path: /etc/kubernetes/secrets-store-csi-providers
+        - name: profiles
+          configMap:
+            name: apparmor-profiles
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Resolving the security vulnerability of verifying the AppArmor Profile to manage access permissions and network communication restrictions for the provider's container.

The AppArmor profile has been authored from the AppArmor profile Go code specified at [Kubernetes's Profile Reference](https://kubernetes.io/docs/tutorials/security/apparmor/#authoring-profiles) in the runtime/default section. The corresponding [AppArmor Profile Github Link](https://github.com/containers/common/blob/main/pkg/apparmor/apparmor_linux_template.go) is in Go and the AppArmor defined in the PR is in YAML to enable binding of the AppArmor Profile to the DaemonSet as ConfigMap.

The AppArmor Profile cannot be set as a YAML key-value pair as defined in the [API Reference](https://kubernetes.io/docs/tutorials/security/apparmor/#pod-annotation) because the provider has a DaemonSet annotation and not a Pod annotation.