### PR TITLE
Prevent the sharing of any host namespaces

### DIFF
--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -68,6 +68,9 @@ spec:
         app: csi-secrets-store-provider-gcp
     spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
       containers:
         - name: provider
           image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:b7dde5ed536b2c6500c9237e14f6851cf8a2ff6d7a72656c3741be38e2cddf4d

--- a/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin-wif.yaml.tmpl
@@ -84,6 +84,9 @@ spec:
         app: csi-secrets-store-provider-gcp
     spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
       containers:
         - name: provider
           image: gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp:$GCP_PROVIDER_SHA

--- a/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
+++ b/test/e2e/templates/provider-gcp-plugin.yaml.tmpl
@@ -67,6 +67,9 @@ spec:
         app: csi-secrets-store-provider-gcp
     spec:
       serviceAccountName: secrets-store-csi-driver-provider-gcp
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
       containers:
         - name: provider
           image: gcr.io/$PROJECT_ID/secrets-store-csi-driver-provider-gcp:$GCP_PROVIDER_SHA


### PR DESCRIPTION
Set the DaemonSet flags(hostNetwork, hostPID, hostIPC) to prevent the sharing of the Host UTS and Host Network namespaces