### PR TITLE
Expose `priorityClassName` variable to the helm chart

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -24,6 +24,9 @@ spec:
       hostNetwork: false
       hostPID: false
       hostIPC: false
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: provider
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -21,6 +21,8 @@ resources:
     cpu: 50m
     memory: 100Mi
 
+priorityClassName: ""
+
 nodeSelector:
   kubernetes.io/os: linux
 


### PR DESCRIPTION
This PR exposes the `priorityClassName` variable to the helm chart, allowing it to be set on the daemonset.

Related to: https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/204

There should be no impact on existing deployments where this variable is not set.