### PR TITLE
Set mount propagation mode to None.

### DIFF
--- a/deploy/provider-gcp-plugin.yaml
+++ b/deploy/provider-gcp-plugin.yaml
@@ -89,6 +89,7 @@ spec:
               value: "/etc/kubernetes/secrets-store-csi-providers"
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              mountPropagation: None
               name: providervol
               readOnly: false
           livenessProbe:


### PR DESCRIPTION
For all volumeMounts defined in the GCP Provider plugin, set the value of parameter mountPropogation to None.