### PR TITLE
Allow namespace customization

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: secrets-store-csi-driver-provider-gcp
 description: A Helm chart to install Google Secret Manager Provider for Secret Store CSI Driver inside a Kubernetes cluster.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.3.0"

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
@@ -11,4 +11,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
+

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "secrets-store-csi-driver-provider-gcp.daemonSetName" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
 spec:

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Currently, it's hard coded to the `kube-system` namespace. This change will allow customizing the namespace based on the release.

This change corroborates what is [already possible to do with the driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml#L6).

Not sure why [the other one](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/336) was closed.