### PR TITLE
Configure and Export Prometheus metrics

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/config"
+	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/csrmetrics"
 	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/vars"
 	"github.com/googleapis/gax-go/v2"
 	"golang.org/x/oauth2"
@@ -297,10 +299,12 @@ func tradeIDBindToken(ctx context.Context, client *http.Client, k8sToken, idPool
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	gcp_iam_metric_recorder := csrmetrics.OutboundRPCStartRecorder("gcp_iam_get_id_bind_token_requests")
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	gcp_iam_metric_recorder(csrmetrics.OutboundRPCStatus(strconv.Itoa(resp.StatusCode)))
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not get idbindtoken token, status: %v", resp.StatusCode)
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -299,12 +299,12 @@ func tradeIDBindToken(ctx context.Context, client *http.Client, k8sToken, idPool
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	gcp_iam_metric_recorder := csrmetrics.OutboundRPCStartRecorder("gcp_iam_get_id_bind_token_requests")
+	gcpIamMetricRecorder := csrmetrics.OutboundRPCStartRecorder("gcp_iam_get_id_bind_token_requests")
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	gcp_iam_metric_recorder(csrmetrics.OutboundRPCStatus(strconv.Itoa(resp.StatusCode)))
+	gcpIamMetricRecorder(csrmetrics.OutboundRPCStatus(strconv.Itoa(resp.StatusCode)))
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not get idbindtoken token, status: %v", resp.StatusCode)
 	}

--- a/csrmetrics/csrmetrics.go
+++ b/csrmetrics/csrmetrics.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package csrmetrics contains metrics definitions to be recorded for monitoring purposes
+// Package csrmetrics (Compute and Storage Resource Metrics)
+// contains metrics definitions to be recorded for monitoring purposes
 package csrmetrics
 
 import (

--- a/csrmetrics/csrmetrics.go
+++ b/csrmetrics/csrmetrics.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package csrmetrics contains metrics definitions to be recorded for monitoring purposes
+package csrmetrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// OutboundRPCStatus is a status string of the outbound RPC metric contains either status code or status string
+type OutboundRPCStatus string
+
+// Status constants for metrics
+const (
+	OutboundRPCStatusNotFound OutboundRPCStatus = "not_found"
+	OutboundRPCStatusError    OutboundRPCStatus = "error"
+	OutboundRPCStatusOK       OutboundRPCStatus = "ok"
+)
+
+var (
+	outboundRPCCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "outbound_rpc_count",
+		Help: "Count of outbound RPCs to GCP",
+	}, []string{"status", "kind"})
+
+	outboundRPCLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "outbound_rpc_latency",
+		Help: "Latency of outbound RPCs to GCP (in seconds)",
+	}, []string{"status", "kind"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		outboundRPCCount,
+		outboundRPCLatency,
+	)
+}
+
+// OutboundRPCStartRecorder marks the start of a outbound RPC operation. Caller is
+// responsible for calling the returned function, which records Prometheus
+// metrics for this operation.
+func OutboundRPCStartRecorder(kind string) func(status OutboundRPCStatus) {
+	start := time.Now()
+
+	return func(status OutboundRPCStatus) {
+		outboundRPCCount.WithLabelValues(string(status), kind).Inc()
+		outboundRPCLatency.WithLabelValues(string(status), kind).Observe(time.Since(start).Seconds())
+	}
+}

--- a/csrmetrics/csrmetrics.go
+++ b/csrmetrics/csrmetrics.go
@@ -32,6 +32,11 @@ const (
 )
 
 var (
+	// Observation function to observe delay
+	// Update this method for unit tests
+	timeSinceSeconds = func(start time.Time) float64 {
+		return time.Since(start).Seconds()
+	}
 	outboundRPCCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "outbound_rpc_count",
 		Help: "Count of outbound RPCs to GCP",
@@ -58,6 +63,6 @@ func OutboundRPCStartRecorder(kind string) func(status OutboundRPCStatus) {
 
 	return func(status OutboundRPCStatus) {
 		outboundRPCCount.WithLabelValues(string(status), kind).Inc()
-		outboundRPCLatency.WithLabelValues(string(status), kind).Observe(time.Since(start).Seconds())
+		outboundRPCLatency.WithLabelValues(string(status), kind).Observe(timeSinceSeconds(start))
 	}
 }

--- a/csrmetrics/csrmetrics_test.go
+++ b/csrmetrics/csrmetrics_test.go
@@ -1,0 +1,190 @@
+package csrmetrics
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertFloat(t *testing.T, left float64, right float64, tol float64) {
+	assert.True(t, math.Abs(left-right) < tol, fmt.Sprintf("abs(Left %v - Right %v) < Tol %v", left, right, tol))
+}
+
+const CountFloatTol float64 = 1e-6
+
+func TestOutboundRPCStartRecorder(t *testing.T) {
+
+	monkey.Patch(time.Now, func() time.Time { return time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC) })
+	recorder := OutboundRPCStartRecorder("test_kind_1")
+
+	monkey.Patch(time.Now, func() time.Time { return time.Date(2024, time.May, 1, 0, 0, 2, 0, time.UTC) })
+	recorder(OutboundRPCStatus("test_status_1"))
+
+	total_count := testutil.CollectAndCount(outboundRPCCount)
+
+	assert.Equal(t, 1, total_count)
+	// check the expected values using the ToFloat64 function
+	assertFloat(t, 1, testutil.ToFloat64(outboundRPCCount.WithLabelValues("test_status_1", "test_kind_1")), CountFloatTol)
+
+	expectedCountMetric := `
+	# HELP outbound_rpc_count Count of outbound RPCs to GCP
+    # TYPE outbound_rpc_count counter
+    outbound_rpc_count{kind="test_kind_1",status="test_status_1"} 1
+	`
+
+	if err := testutil.CollectAndCompare(outboundRPCCount, strings.NewReader(expectedCountMetric)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	expectedLatencyHistogram := `
+	# HELP outbound_rpc_latency Latency of outbound RPCs to GCP (in seconds)
+	# TYPE outbound_rpc_latency histogram
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.005"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.01"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.025"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.05"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.1"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.25"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.5"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="1"} 0
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="2.5"} 1
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="5"} 1
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="10"} 1
+	outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="+Inf"} 1
+	outbound_rpc_latency_sum{kind="test_kind_1",status="test_status_1"} 2
+	outbound_rpc_latency_count{kind="test_kind_1",status="test_status_1"} 1
+	`
+
+	if err := testutil.CollectAndCompare(outboundRPCLatency, strings.NewReader(expectedLatencyHistogram)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	type metricsLables struct {
+		status string
+		kind   string
+	}
+
+	metricsLabels := []metricsLables{
+		{"test_status_1", "test_kind_1"},
+		{"test_status_1", "test_kind_1"},
+		{"test_status_2", "test_kind_1"},
+		{"test_status_2", "test_kind_1"},
+		{"test_status_2", "test_kind_2"},
+		{"test_status_2", "test_kind_2"},
+		{"test_status_2", "test_kind_1"},
+		{"test_status_2", "test_kind_1"},
+		{"test_status_2", "test_kind_2"},
+		{"test_status_2", "test_kind_2"},
+		{"test_status_1", "test_kind_2"},
+		{"test_status_2", "test_kind_2"},
+	}
+
+	latencyArrayDTObjects := []time.Time{
+		time.Date(2024, time.May, 1, 0, 0, 0, 1000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 10000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 20000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 50000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 90000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 200000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 500000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 0, 900000000, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 2, 0, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 4, 0, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 9, 0, time.UTC),
+		time.Date(2024, time.May, 1, 0, 0, 19, 0, time.UTC),
+	}
+	for i := range latencyArrayDTObjects {
+		metricsLable := metricsLabels[i]
+
+		monkey.Patch(time.Now, func() time.Time { return time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC) })
+		recorder := OutboundRPCStartRecorder(metricsLable.kind)
+
+		monkey.Patch(time.Now, func() time.Time { return latencyArrayDTObjects[i] })
+		recorder(OutboundRPCStatus(metricsLable.status))
+	}
+
+	expectedCountMetric = `
+	# HELP outbound_rpc_count Count of outbound RPCs to GCP
+    # TYPE outbound_rpc_count counter
+    outbound_rpc_count{kind="test_kind_1",status="test_status_1"} 3
+    outbound_rpc_count{kind="test_kind_1",status="test_status_2"} 4
+    outbound_rpc_count{kind="test_kind_2",status="test_status_1"} 1
+    outbound_rpc_count{kind="test_kind_2",status="test_status_2"} 5
+	`
+
+	if err := testutil.CollectAndCompare(outboundRPCCount, strings.NewReader(expectedCountMetric)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	exppectedLatencyHistograms := `
+	# HELP outbound_rpc_latency Latency of outbound RPCs to GCP (in seconds)
+    # TYPE outbound_rpc_latency histogram
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.005"} 1
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.01"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.025"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.05"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.1"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.25"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="0.5"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="1"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="2.5"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="5"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="10"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_1",le="+Inf"} 3
+    outbound_rpc_latency_sum{kind="test_kind_1",status="test_status_1"} 2.010001
+    outbound_rpc_latency_count{kind="test_kind_1",status="test_status_1"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.005"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.01"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.025"} 1
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.05"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.1"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.25"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="0.5"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="1"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="2.5"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="5"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="10"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_1",status="test_status_2",le="+Inf"} 4
+    outbound_rpc_latency_sum{kind="test_kind_1",status="test_status_2"} 1.4700000000000002
+    outbound_rpc_latency_count{kind="test_kind_1",status="test_status_2"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.005"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.01"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.025"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.05"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.1"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.25"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="0.5"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="1"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="2.5"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="5"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="10"} 1
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_1",le="+Inf"} 1
+    outbound_rpc_latency_sum{kind="test_kind_2",status="test_status_1"} 9
+    outbound_rpc_latency_count{kind="test_kind_2",status="test_status_1"} 1
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.005"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.01"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.025"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.05"} 0
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.1"} 1
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.25"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="0.5"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="1"} 2
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="2.5"} 3
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="5"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="10"} 4
+    outbound_rpc_latency_bucket{kind="test_kind_2",status="test_status_2",le="+Inf"} 5
+    outbound_rpc_latency_sum{kind="test_kind_2",status="test_status_2"} 25.29
+    outbound_rpc_latency_count{kind="test_kind_2",status="test_status_2"} 5
+	`
+
+	if err := testutil.CollectAndCompare(outboundRPCLatency, strings.NewReader(exppectedLatencyHistograms)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+}

--- a/csrmetrics/csrmetrics_test.go
+++ b/csrmetrics/csrmetrics_test.go
@@ -26,9 +26,9 @@ func TestOutboundRPCStartRecorder(t *testing.T) {
 	monkey.Patch(time.Now, func() time.Time { return time.Date(2024, time.May, 1, 0, 0, 2, 0, time.UTC) })
 	recorder(OutboundRPCStatus("test_status_1"))
 
-	total_count := testutil.CollectAndCount(outboundRPCCount)
+	totalCount := testutil.CollectAndCount(outboundRPCCount)
 
-	assert.Equal(t, 1, total_count)
+	assert.Equal(t, 1, totalCount)
 	// check the expected values using the ToFloat64 function
 	assertFloat(t, 1, testutil.ToFloat64(outboundRPCCount.WithLabelValues("test_status_1", "test_kind_1")), CountFloatTol)
 

--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,14 @@ module github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
 go 1.21
 
 require (
+	bou.ke/monkey v1.0.2
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/iam v1.1.6
 	cloud.google.com/go/secretmanager v1.11.5
 	github.com/google/go-cmp v0.6.0
 	github.com/googleapis/gax-go/v2 v2.12.2
 	github.com/prometheus/client_golang v1.19.0
+	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0
 	golang.org/x/oauth2 v0.18.0
 	google.golang.org/api v0.169.0
@@ -68,6 +70,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.50.0 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ module github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp
 go 1.21
 
 require (
-	bou.ke/monkey v1.0.2
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/iam v1.1.6
 	cloud.google.com/go/secretmanager v1.11.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.112.1 h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
 cloud.google.com/go v0.112.1/go.mod h1:+Vbu+Y1UU+I1rjmzeMOb/8RfkKJK2Gyxi1X6jJCZLo4=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.112.1 h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
 cloud.google.com/go v0.112.1/go.mod h1:+Vbu+Y1UU+I1rjmzeMOb/8RfkKJK2Gyxi1X6jJCZLo4=

--- a/server/server.go
+++ b/server/server.go
@@ -115,14 +115,14 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 			req := &secretmanagerpb.AccessSecretVersionRequest{
 				Name: secret.ResourceName,
 			}
-			sm_metric_recorder := csrmetrics.OutboundRPCStartRecorder("secretmanager_access_secret_version_requests")
+			smMetricRecorder := csrmetrics.OutboundRPCStartRecorder("secretmanager_access_secret_version_requests")
 			resp, err := client.AccessSecretVersion(ctx, req, callAuth)
 			if err != nil {
 				if e, ok := status.FromError(err); ok {
-					sm_metric_recorder(csrmetrics.OutboundRPCStatus(e.Code().String()))
+					smMetricRecorder(csrmetrics.OutboundRPCStatus(e.Code().String()))
 				}
 			} else {
-				sm_metric_recorder(csrmetrics.OutboundRPCStatusOK)
+				smMetricRecorder(csrmetrics.OutboundRPCStatusOK)
 			}
 			results[i] = resp
 			errs[i] = err


### PR DESCRIPTION
Exported metrics are as below:

Request Count and Latency of all the calls to the GCP IAM and GCP Secret Manager.

Example metrics view on `localhost:8095/metrics`

```
# HELP outbound_rpc_count Count of outbound RPCs to GCP
# TYPE outbound_rpc_count counter
outbound_rpc_count{kind="gcp_iam_get_id_bind_token_requests",status="200"} 6
outbound_rpc_count{kind="secretmanager_access_secret_version_requests",status="PermissionDenied"} 4
outbound_rpc_count{kind="secretmanager_access_secret_version_requests",status="ok"} 8
# HELP outbound_rpc_latency Latency of outbound RPCs to GCP (in seconds)
# TYPE outbound_rpc_latency histogram
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.005"} 0
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.01"} 0
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.025"} 4
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.05"} 4
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.1"} 4
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.25"} 4
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="0.5"} 6
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="1"} 6
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="2.5"} 6
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="5"} 6
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="10"} 6
outbound_rpc_latency_bucket{kind="gcp_iam_get_id_bind_token_requests",status="200",le="+Inf"} 6
outbound_rpc_latency_sum{kind="gcp_iam_get_id_bind_token_requests",status="200"} 0.653212285
outbound_rpc_latency_count{kind="gcp_iam_get_id_bind_token_requests",status="200"} 6
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.005"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.01"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.025"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.05"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.1"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.25"} 1
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="0.5"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="1"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="2.5"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="5"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="10"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="PermissionDenied",le="+Inf"} 4
outbound_rpc_latency_sum{kind="secretmanager_access_secret_version_requests",status="PermissionDenied"} 1.425740576
outbound_rpc_latency_count{kind="secretmanager_access_secret_version_requests",status="PermissionDenied"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.005"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.01"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.025"} 0
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.05"} 4
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.1"} 6
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.25"} 6
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="0.5"} 8
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="1"} 8
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="2.5"} 8
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="5"} 8
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="10"} 8
outbound_rpc_latency_bucket{kind="secretmanager_access_secret_version_requests",status="ok",le="+Inf"} 8
outbound_rpc_latency_sum{kind="secretmanager_access_secret_version_requests",status="ok"} 1.095011252
outbound_rpc_latency_count{kind="secretmanager_access_secret_version_requests",status="ok"} 8
```