### PR TITLE
feat: add debug-driver workflow

### DIFF
--- a/.local/Dockerfile
+++ b/.local/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.22-alpine
+
+ENV CGO_ENABLED=0
+ENV GOROOT=/usr/local/go
+ENV GOPATH=${HOME}/go
+ENV PATH=$PATH:${GOROOT}/bin
+
+RUN apk update && apk add --no-cache \
+    git && \
+    go install github.com/go-delve/delve/cmd/dlv@latest
+
+WORKDIR /secrets-store-csi-driver-provider-gcp-codebase
+
+COPY go.mod go.mod
+RUN go mod download
+
+EXPOSE 30123
+
+# these dlv debug arguments replicate driver args from DaemonSet
+ENTRYPOINT ["/go/bin/dlv", "--listen=:30123", "--accept-multiclient", "--headless=true", "--api-version=2", "debug", "./", "--", "-v", "5"]

--- a/.local/README.md
+++ b/.local/README.md
@@ -1,0 +1,29 @@
+# Overview
+This clones the workflow laid out in [secrets store csi driver for local debugging](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/.local).
+
+Please review the sibling flow with its prerequisites, and then you can pick and choose what is needed on this side.
+
+> NOTE: Steps in this guide are not tested by CI/CD. This is just one of the way to locally debug the code and a good starting point.
+
+The debug driver was used to help flesh out issues with the federation of the workload identity. You must have a pod
+that is attempting to mount the secret driver to have the debug breakpoints hit.
+
+Review [docs/fleet-wif-notes.md](../docs/fleet-wif-notes.md) and the example [mypod.yaml.tmpl](../examples/mypod.yaml.tmpl)
+for more details about setting up a consuming pod.
+
+## Creating a docker image
+- Build docker image from [Dockerfile](Dockerfile):
+
+```sh
+docker build -t debug-driver -f .local/Dockerfile .
+```
+
+## Update the debug-driver.yaml
+Update the following items in .local/debug-driver.yaml:
+
+* In the `workload-id-config` update the `audience` to match the audience of the workload identity pool provider.
+* In the `debug-driver` container, update `driver-volume` to utilize a path on your local machine that is configured to be 
+mounted into the pod.
+* In the `gcp-ksa` volume, update the `audience` to match the audience of the workload identity pool provider.
+
+Deploy the debug-driver and the consuming pod. You can then hook up your IDE to the debug-driver container via delve.

--- a/.local/debug-driver.yaml
+++ b/.local/debug-driver.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workload-id-config
+  namespace: kube-system
+immutable: false
+data:
+  config: >-
+    {
+      "audience":"//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+      "credential_source":{
+        "file":"/var/run/secrets/tokens/gcp-ksa/token",
+        "format":{
+          "type":"text"
+        }
+      },
+      "subject_token_type":"urn:ietf:params:oauth:token-type:jwt",
+      "token_info_url":"https://sts.googleapis.com/v1/introspect",
+      "token_url":"https://sts.googleapis.com/v1/token",
+      "type":"external_account",
+      "universe_domain":"googleapis.com"
+    }
+
+---
+# Separate deployment to manage actual driver debugging independent of node registrar and livenessprobe
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: debug-driver
+  namespace: kube-system
+spec:
+  replicas: 1 # Keep single replica for debugging
+  selector:
+    matchLabels:
+      app: debug-driver
+  template:
+    metadata:
+      labels:
+        app: debug-driver
+    spec:
+      serviceAccountName: secrets-store-csi-driver-provider-gcp
+      initContainers:
+        - name: chown-provider-mount
+          image: busybox
+          command:
+            - chown
+            - "1000:1000"
+            - /etc/kubernetes/secrets-store-csi-providers
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      containers:
+        - name: debug-driver
+          image: debug-driver:latest # dlv debug image built locally
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /secrets-store-csi-driver-provider-gcp-codebase
+              name: driver-volume
+            - name: providervol
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+              mountPropagation: None
+              readOnly: false
+            - name: "gcp-ksa"
+              mountPath: "/var/run/secrets/tokens/gcp-ksa"
+              readOnly: true
+              mountPropagation: None
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          env:
+            - name: TARGET_DIR
+              value: /etc/kubernetes/secrets-store-csi-providers
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/run/secrets/tokens/gcp-ksa/google-application-credentials.json
+            - name: GAIA_TOKEN_EXCHANGE_ENDPOINT
+              value: https://sts.googleapis.com/v1/token
+      volumes:
+        - name: driver-volume
+          hostPath:
+            path: # /path/to/your/secrets-store-csi-driver-provider-gcp/codebase/on/host
+            type: Directory
+        - name: providervol
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+        - name: "gcp-ksa"
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: # //iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+                  expirationSeconds: 172800
+                  path: token
+              - configMap:
+                  name: workload-id-config
+                  items:
+                      - key: config
+                        path: google-application-credentials.json
+                  optional: false
+
+---
+# Service to connect dlv apis
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-debug
+  namespace: kube-system
+spec:
+  type: NodePort
+  selector:
+    app: debug-driver
+  ports:
+  - name: debug
+    port: 30123
+    targetPort: 30123
+    nodePort: 30123


### PR DESCRIPTION
The PR adds a debug workflow similar to the [secrets-store-csi-driver local workflow](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/.local).

