### PR TITLE
Add support to extract key value from json secret

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,8 @@ type Secret struct {
 	// Path is the relative path where the contents of the secret are written.
 	Path string `json:"path" yaml:"path"`
 
+	ExtractKey string `json:"extractKey" yaml:"extractKey"`
+
 	// Mode is the optional file mode for the file containing the secret. Must be
 	// an octal value between 0000 and 0777 or a decimal value between 0 and 511
 	Mode *int32 `json:"mode,omitempty" yaml:"mode,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -278,6 +278,41 @@ func TestParse(t *testing.T) {
 				AuthPodADC:  true,
 			},
 		},
+		{
+			name: "secrets with extractKey",
+			in: &MountParams{
+				Attributes: `
+				{
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n  extractKey: user\n",
+					"csi.storage.k8s.io/pod.namespace": "default",
+					"csi.storage.k8s.io/pod.name": "mypod",
+					"csi.storage.k8s.io/pod.uid": "123",
+					"csi.storage.k8s.io/serviceAccount.name": "mysa"
+				}
+				`,
+				KubeSecrets: "{}",
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+			},
+			want: &MountConfig{
+				Secrets: []*Secret{
+					{
+						ResourceName: "projects/project/secrets/test/versions/latest",
+						FileName:     "good1.txt",
+						ExtractKey:   "user",
+					},
+				},
+				PodInfo: &PodInfo{
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
+				},
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+				AuthPodADC:  true,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/examples/app-secrets-with-extract-key.yaml.tmpl
+++ b/examples/app-secrets-with-extract-key.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: app-secrets-with-extract-key
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/secrets/testsecret/versions/latest"
+        path: "good1.txt"
+        extractKey: "user"
+      - resourceName: "projects/$PROJECT_ID/locations/us-central1/secrets/testsecret/versions/latest"
+        path: "good2.txt"
+        extractKey: "user"
+
+# NOTE: Please provide the secret and regional secret in JSON format, including the key for "user" 
+# to ensure this example functions correctly. The regional secret must either be located in the 
+# `us-central1` region or you need to change the location in the resourceName.

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -188,10 +189,39 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 		}
 
 		result := results[i]
+		extractKey := secret.ExtractKey
+		var content []byte
+
+		// If extractKey is null, then set the entire data
+		if extractKey == "" {
+			content = result.Payload.Data
+		} else {
+			var data map[string]interface{}
+			err := json.Unmarshal(result.Payload.Data, &data)
+			if err != nil {
+				return nil, fmt.Errorf("secret data not in JSON format, %v", err)
+			}
+
+			value, ok := data[extractKey]
+
+			// If the key is not present, an error will be raised
+			if !ok {
+				return nil, fmt.Errorf("key %v does not exist at the secret path", extractKey)
+			} else {
+				data_content, ok := value.(string)
+
+				// If there is a type conversion error
+				if !ok {
+					return nil, fmt.Errorf("wrong type for content (%v), expected string", value.(string))
+				}
+				content = []byte(data_content)
+			}
+		}
+
 		out.Files = append(out.Files, &v1alpha1.File{
 			Path:     secret.PathString(),
 			Mode:     mode,
-			Contents: result.Payload.Data,
+			Contents: content,
 		})
 		klog.V(5).InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
 

--- a/server/server.go
+++ b/server/server.go
@@ -208,13 +208,13 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 			if !ok {
 				return nil, fmt.Errorf("key %v does not exist at the secret path", extractKey)
 			} else {
-				data_content, ok := value.(string)
+				dataContent, ok := value.(string)
 
 				// If there is a type conversion error
 				if !ok {
 					return nil, fmt.Errorf("wrong type for content (%v), expected string", value.(string))
 				}
-				content = []byte(data_content)
+				content = []byte(dataContent)
 			}
 		}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -301,6 +301,220 @@ func TestHandleMountEventForRegionalSecret(t *testing.T) {
 	}
 }
 
+func TestHandleMountEventForExtractKey(t *testing.T) {
+	cfg := &config.MountConfig{
+		Secrets: []*config.Secret{
+			{
+				ResourceName: "projects/project/secrets/test/versions/latest",
+				FileName:     "good1.txt",
+			},
+			{
+				ResourceName: "projects/project/secrets/test/versions/latest",
+				FileName:     "good2.txt",
+				ExtractKey:   "user",
+			},
+		},
+		Permissions: 777,
+		PodInfo: &config.PodInfo{
+			Namespace: "default",
+			Name:      "test-pod",
+		},
+	}
+
+	want := &v1alpha1.MountResponse{
+		ObjectVersion: []*v1alpha1.ObjectVersion{
+			{
+				Id:      "projects/project/secrets/test/versions/latest",
+				Version: "projects/project/secrets/test/versions/2",
+			},
+			{
+				Id:      "projects/project/secrets/test/versions/latest",
+				Version: "projects/project/secrets/test/versions/2",
+			},
+		},
+		Files: []*v1alpha1.File{
+			{
+				Path:     "good1.txt",
+				Mode:     777,
+				Contents: []byte(`{"user": "admin", "password": "password@1234"}`),
+			},
+			{
+				Path:     "good2.txt",
+				Mode:     777,
+				Contents: []byte("admin"),
+			},
+		},
+	}
+
+	client := mock(t, &mockSecretServer{
+		accessFn: func(ctx context.Context, _ *secretmanagerpb.AccessSecretVersionRequest) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			return &secretmanagerpb.AccessSecretVersionResponse{
+				Name: "projects/project/secrets/test/versions/2",
+				Payload: &secretmanagerpb.SecretPayload{
+					Data: []byte(`{"user": "admin", "password": "password@1234"}`),
+				},
+			}, nil
+		},
+	})
+
+	regionalClients := make(map[string]*secretmanager.Client)
+
+	got, err := handleMountEvent(context.Background(), client, NewFakeCreds(), cfg, regionalClients, []option.ClientOption{})
+	if err != nil {
+		t.Errorf("handleMountEvent() got err = %v, want err = nil", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("handleMountEvent() returned unexpected response (-want +got):\n%s", diff)
+	}
+}
+func TestHandleMountEventForRegionalSecretExtractKey(t *testing.T) {
+	cfg := &config.MountConfig{
+		Secrets: []*config.Secret{
+			{
+				ResourceName: "projects/project/locations/us-central1/secrets/test/versions/latest",
+				FileName:     "good1.txt",
+			},
+			{
+				ResourceName: "projects/project/locations/us-central1/secrets/test/versions/latest",
+				FileName:     "good2.txt",
+				ExtractKey:   "user",
+			},
+		},
+		Permissions: 777,
+		PodInfo: &config.PodInfo{
+			Namespace: "default",
+			Name:      "test-pod",
+		},
+	}
+
+	want := &v1alpha1.MountResponse{
+		ObjectVersion: []*v1alpha1.ObjectVersion{
+			{
+				Id:      "projects/project/locations/us-central1/secrets/test/versions/latest",
+				Version: "projects/project/locations/us-central1/secrets/test/versions/2",
+			},
+			{
+				Id:      "projects/project/locations/us-central1/secrets/test/versions/latest",
+				Version: "projects/project/locations/us-central1/secrets/test/versions/2",
+			},
+		},
+		Files: []*v1alpha1.File{
+			{
+				Path:     "good1.txt",
+				Mode:     777,
+				Contents: []byte(`{"user":"admin", "password":"password@1234"}`),
+			},
+			{
+				Path:     "good2.txt",
+				Mode:     777,
+				Contents: []byte("admin"),
+			},
+		},
+	}
+
+	regionalClient := mock(t, &mockSecretServer{
+		accessFn: func(ctx context.Context, _ *secretmanagerpb.AccessSecretVersionRequest) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			return &secretmanagerpb.AccessSecretVersionResponse{
+				Name: "projects/project/locations/us-central1/secrets/test/versions/2",
+				Payload: &secretmanagerpb.SecretPayload{
+					Data: []byte(`{"user":"admin", "password":"password@1234"}`),
+				},
+			}, nil
+		},
+	})
+
+	regionalClients := make(map[string]*secretmanager.Client)
+	regionalClients["us-central1"] = regionalClient
+
+	got, err := handleMountEvent(context.Background(), regionalClient, NewFakeCreds(), cfg, regionalClients, []option.ClientOption{})
+	if err != nil {
+		t.Errorf("handleMountEvent() got err = %v, want err = nil", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("handleMountEvent() returned unexpected response (-want +got):\n%s", diff)
+	}
+}
+func TestHandleMountEventForMultipleSecretsExtractKey(t *testing.T) {
+	cfg := &config.MountConfig{
+		Secrets: []*config.Secret{
+			{
+				ResourceName: "projects/project/secrets/test1/versions/latest",
+				FileName:     "good1.txt",
+				ExtractKey:   "user",
+			},
+			{
+				ResourceName: "projects/project/locations/us-central1/secrets/test2/versions/latest",
+				FileName:     "good2.txt",
+				ExtractKey:   "user",
+			},
+		},
+		Permissions: 777,
+		PodInfo: &config.PodInfo{
+			Namespace: "default",
+			Name:      "test-pod",
+		},
+	}
+
+	want := &v1alpha1.MountResponse{
+		ObjectVersion: []*v1alpha1.ObjectVersion{
+			{
+				Id:      "projects/project/secrets/test1/versions/latest",
+				Version: "projects/project/secrets/test1/versions/2",
+			},
+			{
+				Id:      "projects/project/locations/us-central1/secrets/test2/versions/latest",
+				Version: "projects/project/locations/us-central1/secrets/test2/versions/2",
+			},
+		},
+		Files: []*v1alpha1.File{
+			{
+				Path:     "good1.txt",
+				Mode:     777,
+				Contents: []byte("admin"),
+			},
+			{
+				Path:     "good2.txt",
+				Mode:     777,
+				Contents: []byte("admin2"),
+			},
+		},
+	}
+
+	client := mock(t, &mockSecretServer{
+		accessFn: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			switch req.Name {
+			case "projects/project/secrets/test1/versions/latest":
+				return &secretmanagerpb.AccessSecretVersionResponse{
+					Name: "projects/project/secrets/test1/versions/2",
+					Payload: &secretmanagerpb.SecretPayload{
+						Data: []byte(`{"user":"admin", "password":"password@1234"}`),
+					},
+				}, nil
+			case "projects/project/locations/us-central1/secrets/test2/versions/latest":
+				return &secretmanagerpb.AccessSecretVersionResponse{
+					Name: "projects/project/locations/us-central1/secrets/test2/versions/2",
+					Payload: &secretmanagerpb.SecretPayload{
+						Data: []byte(`{"user":"admin2", "password":"password@12345"}`),
+					},
+				}, nil
+				default:
+					return nil, nil
+			}
+		},
+	})
+
+	regionalClients := make(map[string]*secretmanager.Client)
+	regionalClients["us-central1"] = client
+
+	got, err := handleMountEvent(context.Background(), client, NewFakeCreds(), cfg, regionalClients, []option.ClientOption{})
+	if err != nil {
+		t.Errorf("handleMountEvent() got err = %v, want err = nil", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("handleMountEvent() returned unexpected response (-want +got):\n%s", diff)
+	}
+}
+
 // mock builds a secretmanager.Client talking to a real in-memory secretmanager
 // GRPC server of the *mockSecretServer.
 func mock(t testing.TB, m *mockSecretServer) *secretmanager.Client {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -497,8 +497,8 @@ func TestHandleMountEventForMultipleSecretsExtractKey(t *testing.T) {
 						Data: []byte(`{"user":"admin2", "password":"password@12345"}`),
 					},
 				}, nil
-				default:
-					return nil, nil
+			default:
+				return nil, nil
 			}
 		},
 	})


### PR DESCRIPTION
This PR adds support to extract key value from JSON secret

Related to: #229

We have tested the `extractKey` field for the following scenarios:
- Extract key value from JSON secret for global.
- Extract key value from JSON secret for regional.
- When `extractKey` field is empty or is not provided, then the whole secret value is mounted.