### PR TITLE
Added support for fetching secrets based on labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,15 @@ type Secret struct {
 	// Mode is the optional file mode for the file containing the secret. Must be
 	// an octal value between 0000 and 0777 or a decimal value between 0 and 511
 	Mode *int32 `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	// ProjectID is the ID of the Google Cloud project where the secrets are stored.
+	ProjectID string `json:"projectID" yaml:"projectID"`
+
+	// Versions is the version of the secrets to fetch. If set to "latest", fetches the latest version.
+	Versions string `json:"versions" yaml:"versions"`
+
+	// Labels is the labels of the secrets to fetch.
+	Labels map[string]string `json:"labels" yaml:"labels"`
 }
 
 // PodInfo includes details about the pod that is receiving the mount event.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,6 +61,41 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name: "single secret with project ID, version, and labels",
+			in: &MountParams{
+				Attributes: `
+                {
+                    "secrets": "- projectID: \"my-project\"\n  versions: \"v1\"\n  labels: {\"key\": \"value\"}\n",
+                    "csi.storage.k8s.io/pod.namespace": "default",
+                    "csi.storage.k8s.io/pod.name": "mypod",
+                    "csi.storage.k8s.io/pod.uid": "123",
+                    "csi.storage.k8s.io/serviceAccount.name": "mysa"
+                }
+                `,
+				KubeSecrets: "{}",
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+			},
+			want: &MountConfig{
+				Secrets: []*Secret{
+					{
+						ProjectID: "my-project",
+						Versions:  "v1",
+						Labels:    map[string]string{"key": "value"},
+					},
+				},
+				PodInfo: &PodInfo{
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
+				},
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+				AuthPodADC:  true,
+			},
+		},
+		{
 			name: "single secret with mode",
 			in: &MountParams{
 				Attributes: `

--- a/examples/fetch-secrets-labels.yaml.tmpl
+++ b/examples/fetch-secrets-labels.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: app-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - projectID: $PROJECT_ID
+        versions: "latest"
+        labels:
+          dev: "test"
+          location: "us-east1"

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"hash/crc32"
 	"math"
 	"os"
 	"regexp"
@@ -29,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/config"
 	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/csrmetrics"
 	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/iterator"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
@@ -43,6 +45,103 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
+
+func fetchSecrets(ctx context.Context, projectId string, version string, labels map[string]string, regionalClients map[string]*secretmanager.Client, callAuth gax.CallOption, smOpts []option.ClientOption) ([]*secretmanagerpb.AccessSecretVersionResponse, error) {
+	var parent string
+	var filter string
+	location, ok := labels["location"]
+	var secretClient *secretmanager.Client
+
+	if ok {
+		// Remove location from labels
+		delete(labels, "location")
+		parent = fmt.Sprintf("projects/%s/locations/%s", projectId, location)
+		filter = buildFilter(labels)
+
+		if _, ok := regionalClients[location]; !ok {
+			ep := option.WithEndpoint(fmt.Sprintf("secretmanager.%s.rep.googleapis.com:443", location))
+			regionalClient, err := secretmanager.NewClient(ctx, append(smOpts, ep)...)
+			if err != nil {
+				return nil, err
+			}
+			regionalClients[location] = regionalClient
+		}
+		secretClient = regionalClients[location]
+	} else {
+		parent = fmt.Sprintf("projects/%s", projectId)
+		filter = buildFilter(labels)
+		client, err := secretmanager.NewClient(ctx, smOpts...)
+		if err != nil {
+			return nil, err
+		}
+		secretClient = client
+	}
+	klog.InfoS("fetching secrets", "parent", parent, "filter", filter)
+
+	req := &secretmanagerpb.ListSecretsRequest{
+		Parent: parent,
+		Filter: filter,
+	}
+
+	var secrets []*secretmanagerpb.Secret
+
+	it := secretClient.ListSecrets(ctx, req, callAuth)
+
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		secrets = append(secrets, resp)
+	}
+	klog.InfoS("Total secrets fetched", "count", fmt.Sprintf("%d", len(secrets)))
+
+	// Optimal limit for max number of secrets can be fetched without causing CSI Secret Store Driver to behave abnormally
+	if len(secrets) > 1000 {
+		err := status.Error(codes.Internal, "too many secrets")
+		klog.ErrorS(err, "Too many secrets found while filtering", "count", fmt.Sprintf("%d", len(secrets)))
+		return nil, err
+	}
+
+	if len(secrets) == 0 {
+		err := status.Error(codes.Internal, "No secrets matched.")
+		klog.ErrorS(err, "No secrets matched while filtering", "count", fmt.Sprintf("%d", len(secrets)))
+		return nil, err
+	}
+
+	var result []*secretmanagerpb.AccessSecretVersionResponse
+	for _, secret := range secrets {
+		versionReq := &secretmanagerpb.AccessSecretVersionRequest{
+			Name: fmt.Sprintf("%s/versions/%s", secret.Name, version),
+		}
+		versionResp, err := secretClient.AccessSecretVersion(ctx, versionReq, callAuth)
+		if err != nil {
+			// If the version is disabled, destroyed, or does not exist, skip it
+			continue
+		}
+		crc32c := crc32.MakeTable(crc32.Castagnoli)
+		checksum := int64(crc32.Checksum(versionResp.Payload.Data, crc32c))
+		if checksum != *versionResp.Payload.DataCrc32C {
+			err := status.Error(codes.Internal, "Data corruption detected.")
+			klog.ErrorS(err, "Secret value is corrupted", "secret", secret.Name, "version", version)
+			continue
+		}
+		result = append(result, versionResp)
+	}
+	return result, nil
+}
+
+func buildFilter(labels map[string]string) string {
+	var filterParts []string
+	for key, value := range labels {
+		filterParts = append(filterParts, fmt.Sprintf("labels.%s=%s", key, value))
+	}
+	return strings.Join(filterParts, " AND ")
+}
 
 type Server struct {
 	RuntimeVersion        string
@@ -111,7 +210,37 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 
 	// In parallel fetch all secrets needed for the mount
 	wg := sync.WaitGroup{}
+	out := &v1alpha1.MountResponse{}
+	ovs := []*v1alpha1.ObjectVersion{}
 	for i, secret := range cfg.Secrets {
+		// Check if projectID, version, labels are provided
+		if secret.ProjectID != "" && secret.Versions != "" && secret.Labels != nil {
+
+			// Use the fetchSecrets function to fetch secrets
+			secrets, err := fetchSecrets(ctx, secret.ProjectID, secret.Versions, secret.Labels, regionalClients, callAuth, smOpts)
+			if err != nil {
+				errs[i] = err
+				continue
+			}
+
+			for _, s := range secrets {
+				file := &v1alpha1.File{
+					Path:     strings.ReplaceAll(s.Name[:strings.Index(s.Name, "/versions/")], "/", "_"), // Use the secret name as the file name
+					Mode:     int32(cfg.Permissions),
+					Contents: s.Payload.Data,
+				}
+				out.Files = append(out.Files, file)
+
+				// Add object version to response
+				// Assuming ovs is a slice of ObjectVersion
+				ovs = append(ovs, &v1alpha1.ObjectVersion{
+					Id:      secret.ProjectID + "/" + secret.Versions,
+					Version: secret.Versions,
+				})
+			}
+			klog.InfoS("Files created based on provided labels", "files", fmt.Sprintf("%d", len(ovs)), "skipped", fmt.Sprintf("%d", len(secrets)-len(ovs)))
+			continue
+		}
 		loc, err := locationFromSecretResource(secret.ResourceName)
 		if err != nil {
 			errs[i] = err
@@ -173,31 +302,31 @@ func handleMountEvent(ctx context.Context, client *secretmanager.Client, creds c
 		return nil, err
 	}
 
-	out := &v1alpha1.MountResponse{}
-
 	// Add secrets to response.
-	ovs := make([]*v1alpha1.ObjectVersion, len(cfg.Secrets))
 	for i, secret := range cfg.Secrets {
-		if cfg.Permissions > math.MaxInt32 {
-			return nil, fmt.Errorf("invalid file permission %d", cfg.Permissions)
-		}
-		// #nosec G115 Checking limit
-		mode := int32(cfg.Permissions)
-		if secret.Mode != nil {
-			mode = *secret.Mode
-		}
+		if secret.ProjectID == "" && secret.Versions == "" && len(secret.Labels) == 0 {
 
-		result := results[i]
-		out.Files = append(out.Files, &v1alpha1.File{
-			Path:     secret.PathString(),
-			Mode:     mode,
-			Contents: result.Payload.Data,
-		})
-		klog.V(5).InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
+			if cfg.Permissions > math.MaxInt32 {
+				return nil, fmt.Errorf("invalid file permission %d", cfg.Permissions)
+			}
+			// #nosec G115 Checking limit
+			mode := int32(cfg.Permissions)
+			if secret.Mode != nil {
+				mode = *secret.Mode
+			}
 
-		ovs[i] = &v1alpha1.ObjectVersion{
-			Id:      secret.ResourceName,
-			Version: result.GetName(),
+			result := results[i]
+			out.Files = append(out.Files, &v1alpha1.File{
+				Path:     secret.PathString(),
+				Mode:     mode,
+				Contents: result.Payload.Data,
+			})
+			klog.V(5).InfoS("added secret to response", "resource_name", secret.ResourceName, "file_name", secret.FileName, "pod", klog.ObjectRef{Namespace: cfg.PodInfo.Namespace, Name: cfg.PodInfo.Name})
+
+			ovs = append(ovs, &v1alpha1.ObjectVersion{
+				Id:      secret.ResourceName,
+				Version: result.GetName(),
+			})
 		}
 	}
 	out.ObjectVersion = ovs


### PR DESCRIPTION
The PR focuses on retrieving secrets based on specified labels.
- For each secret that matches the filter, the file name will correspond to the resource path of that secret (e.g., projects/<project_id>/secrets/<secret_id>).
- The system has successfully fetched up to 1,000 secrets, leading to the decision to set a cap at this limit.
- Limitation: Attempting to mount the value of larger secrets resulted in a resource exhaustion error due to a size exceeding 4 MB.

Related to: #384

We have tested this with the following scenarios:
- Attempting to mount more than 1,000 secrets results in a "Too many secrets" error.
- If there are no secrets which matches the filter, then returns "No secrets matched while filtering."
- Relevant logs messages are added at each stage.
-  **Global Secrets (All scenarios functioning as expected):**
    - Secrets with no versions are not mounted.
    - Secrets with destroyed version is not mounted and are skipped.
    - Secrets with disabled version is not mounted and are skipped.
    - Secrets with enabled version is successfully mounted.
- **Regional Secrets (All scenarios functioning as expected)**
(Location value provided in labels)
    - Secrets with no versions are not mounted.
    - Secrets with destroyed version is not mounted and are skipped.
    - Secrets with the disabled version is not mounted and are skipped.
    - Secrets with enabled version is successfully mounted.