### PR TITLE
Added relevant parameter manager admin roles

### DIFF
--- a/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -86,6 +86,9 @@ spec:
     - members:
         - serviceAccount:secretmanager-csi-build.svc.id.goog[default/test-cluster-sa]
       role: roles/secretmanager.secretAccessor
+    - members:
+        - serviceAccount:secretmanager-csi-build.svc.id.goog[default/test-cluster-sa]
+      role: roles/parametermanager.parameterAccessor
     # service account agent bindings
     - members:
         - serviceAccount:service-735463103342@compute-system.iam.gserviceaccount.com

--- a/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -59,10 +59,10 @@ spec:
       role: roles/secretmanager.admin
     - members:
         - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
-      role: roles/secretmanager.admin
+      role: roles/parametermanager.admin
     - members:
         - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
-      role: roles/parametermanager.admin
+      role: roles/iam.securityAdmin
     - members:
         - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
       role: roles/monitoring.metricWriter

--- a/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -59,7 +59,10 @@ spec:
       role: roles/secretmanager.admin
     - members:
         - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
-      role: roles/iam.securityAdmin
+      role: roles/secretmanager.admin
+    - members:
+        - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
+      role: roles/parametermanager.admin
     - members:
         - serviceAccount:cnrm-system@secretmanager-csi-build.iam.gserviceaccount.com
       role: roles/monitoring.metricWriter

--- a/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
+++ b/test/infra/managed/namespaces/secretmanager-csi-build/iam-policy.yaml
@@ -76,6 +76,12 @@ spec:
     - members:
         - serviceAccount:e2e-test-sa@secretmanager-csi-build.iam.gserviceaccount.com
       role: roles/secretmanager.admin
+    - members:
+        - serviceAccount:e2e-test-sa@secretmanager-csi-build.iam.gserviceaccount.com
+      role: roles/parametermanager.parameterVersionManager
+    - members:
+        - serviceAccount:e2e-test-sa@secretmanager-csi-build.iam.gserviceaccount.com
+      role: roles/parametermanager.admin
     # for test cluster to access secrets
     - members:
         - serviceAccount:secretmanager-csi-build.svc.id.goog[default/test-cluster-sa]


### PR DESCRIPTION
1. Added relevant parameter manager admin permissions to e2e service account as getting permission denied errors in e2e tests 

```
TEST: + /google-cloud-sdk/bin/gcloud secrets delete testsecret-1376340465-extract --project secretmanager-csi-build --quiet
TEST: ERROR: (gcloud.secrets.delete) NOT_FOUND: Secret [projects/735463103342/secrets/testsecret-1376340465-extract] not found. This command is authenticated as e2e-test-sa@secretmanager-csi-build.iam.gserviceaccount.com which is the active account specified by the [core/account] property.
TEST: 
TEST: + /google-cloud-sdk/bin/gcloud parametermanager parameters versions delete testparameterversionyaml-1030579760 --parameter testparameteryaml-841516529 --location global --project secretmanager-csi-build --quiet
TEST: ERROR: (gcloud.parametermanager.parameters.versions.delete) PERMISSION_DENIED: Permission 'parametermanager.parameterVersions.delete' denied on resource '//parametermanager.googleapis.com/projects/secretmanager-csi-build/locations/global/parameters/testparameteryaml-841516529/versions/testparameterversionyaml-1030579760' (or it may not exist). This command is authenticated as e2e-test-sa@secretmanager-csi-build.iam.gserviceaccount.com which is the active account specified by the [core/account] property.
TEST: - '@type': type.googleapis.com/google.rpc.ErrorInfo
TEST:   domain: parametermanager.googleapis.com
TEST:   metadata:
TEST:     permission: parametermanager.parameterVersions.delete
TEST:     resource: projects/secretmanager-csi-build/locations/global/parameters/testparameteryaml-841516529/versions/testparameterversionyaml-1030579760
TEST:   reason: IAM_PERMISSION_DENIED
```