### PR TITLE
Correct the helm charts as the job failed when we released 1.8

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -3,4 +3,4 @@ name: secrets-store-csi-driver-provider-gcp
 description: A Helm chart to install Google Secret Manager Provider for Secret Store CSI Driver inside a Kubernetes cluster.
 type: application
 version: 0.1.0
-appVersion: "1.7.0"
+appVersion: "1.8.0"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -7,7 +7,7 @@ serviceAccount:
 image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
   pullPolicy: IfNotPresent
-  hash: sha256:16206089381c7f9b70442b4ed97e65bc34daec1ee26a5c5de7453a24f0f1de13
+  hash: sha256:430b629bc757e5e6aa667793645b64af232519003a976dd4046c050b1ac8acbb
 
 app: csi-secrets-store-provider-gcp
 


### PR DESCRIPTION
Failed job 
https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/actions/runs/14396802787/job/40373862575?pr=542