### PR TITLE
[1.9.0] Upadte the helm charts

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -3,4 +3,4 @@ name: secrets-store-csi-driver-provider-gcp
 description: A Helm chart to install Google Secret Manager Provider for Secret Store CSI Driver inside a Kubernetes cluster.
 type: application
 version: 0.1.0
-appVersion: "1.8.0"
+appVersion: "1.9.0"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -7,7 +7,7 @@ serviceAccount:
 image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
   pullPolicy: IfNotPresent
-  hash: sha256:430b629bc757e5e6aa667793645b64af232519003a976dd4046c050b1ac8acbb
+  hash: sha256:183c92fbe7905ebe09ccec6496e91b7b615b1e88096576bc100d46fe97fe9770
 
 app: csi-secrets-store-provider-gcp
 


### PR DESCRIPTION
Due to direct commit on main e6c6bf3b56a2d0ff1a21a4057ebe26ee07e9f28f, release workflow did not trigger. Hence manually updating the main charts.