### PR TITLE
feat: Added feature to base64 decode the value in GSM

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type Secret struct {
 
 	ExtractJSONKey string `json:"extractJSONKey" yaml:"extractJSONKey"`
 	ExtractYAMLKey string `json:"extractYAMLKey" yaml:"extractYAMLKey"`
+	DecodeBase64   bool   `json:"decodeBase64" yaml:"decodeBase64"`
 
 	// Mode is the optional file mode for the file containing the secret. Must be
 	// an octal value between 0000 and 0777 or a decimal value between 0 and 511

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -313,6 +313,77 @@ func TestParse(t *testing.T) {
 				AuthPodADC:  true,
 			},
 		},
+		{
+			name: "secrets with decodeBase64",
+			in: &MountParams{
+				Attributes: `
+				{
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n  decodeBase64: true\n",
+					"csi.storage.k8s.io/pod.namespace": "default",
+					"csi.storage.k8s.io/pod.name": "mypod",
+					"csi.storage.k8s.io/pod.uid": "123",
+					"csi.storage.k8s.io/serviceAccount.name": "mysa"
+				}
+				`,
+				KubeSecrets: "{}",
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+			},
+			want: &MountConfig{
+				Secrets: []*Secret{
+					{
+						ResourceName: "projects/project/secrets/test/versions/latest",
+						FileName:     "good1.txt",
+						DecodeBase64: true,
+					},
+				},
+				PodInfo: &PodInfo{
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
+				},
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+				AuthPodADC:  true,
+			},
+		},
+		{
+			name: "secrets with extractJSONKey and decodeBase64",
+			in: &MountParams{
+				Attributes: `
+				{
+					"secrets": "- resourceName: \"projects/project/secrets/test/versions/latest\"\n  fileName: \"good1.txt\"\n  extractJSONKey: data\n  decodeBase64: true\n",
+					"csi.storage.k8s.io/pod.namespace": "default",
+					"csi.storage.k8s.io/pod.name": "mypod",
+					"csi.storage.k8s.io/pod.uid": "123",
+					"csi.storage.k8s.io/serviceAccount.name": "mysa"
+				}
+				`,
+				KubeSecrets: "{}",
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+			},
+			want: &MountConfig{
+				Secrets: []*Secret{
+					{
+						ResourceName:   "projects/project/secrets/test/versions/latest",
+						FileName:       "good1.txt",
+						ExtractJSONKey: "data",
+						DecodeBase64:   true,
+					},
+				},
+				PodInfo: &PodInfo{
+					Namespace:      "default",
+					Name:           "mypod",
+					UID:            "123",
+					ServiceAccount: "mysa",
+				},
+				TargetPath:  "/tmp/foo",
+				Permissions: 777,
+				AuthPodADC:  true,
+			},
+		},
 	}
 	t.Setenv("ALLOW_NODE_PUBLISH_SECRET", "true")
 	for _, tc := range tests {

--- a/server/resourcefetcher.go
+++ b/server/resourcefetcher.go
@@ -33,6 +33,7 @@ type resourceFetcher struct {
 	Mode           *int32
 	ExtractJSONKey string
 	ExtractYAMLKey string
+	DecodeBase64   bool
 }
 
 // Resource represents the Resource that is fetched.

--- a/server/secretfetcher_decodebase64_test.go
+++ b/server/secretfetcher_decodebase64_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/util"
@@ -65,7 +66,7 @@ func TestBase64ProcessingLogic(t *testing.T) {
 				content, err = util.ExtractContentUsingJSONKey([]byte(tt.secretData), tt.extractJSONKey)
 				if err != nil {
 					if tt.expectError && tt.expectedErrSubstr != "" {
-						if !containsSubstring(err.Error(), tt.expectedErrSubstr) {
+						if !strings.Contains(err.Error(), tt.expectedErrSubstr) {
 							t.Errorf("expected error to contain %q, got %q", tt.expectedErrSubstr, err.Error())
 						}
 					} else if !tt.expectError {
@@ -82,7 +83,7 @@ func TestBase64ProcessingLogic(t *testing.T) {
 				decoded, err := util.DecodeBase64Content(content)
 				if err != nil {
 					if tt.expectError && tt.expectedErrSubstr != "" {
-						if !containsSubstring(err.Error(), tt.expectedErrSubstr) {
+						if !strings.Contains(err.Error(), tt.expectedErrSubstr) {
 							t.Errorf("expected error to contain %q, got %q", tt.expectedErrSubstr, err.Error())
 						}
 					} else if !tt.expectError {
@@ -104,12 +105,3 @@ func TestBase64ProcessingLogic(t *testing.T) {
 	}
 }
 
-// containsSubstring checks if a string contains a substring
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/server/secretfetcher_decodebase64_test.go
+++ b/server/secretfetcher_decodebase64_test.go
@@ -10,13 +10,13 @@ import (
 // TestBase64ProcessingLogic tests the base64 processing logic that would be used in secret fetching
 func TestBase64ProcessingLogic(t *testing.T) {
 	tests := []struct {
-		name               string
-		secretData         string
-		extractJSONKey     string
-		decodeBase64       bool
-		expectedPayload    []byte
-		expectError        bool
-		expectedErrSubstr  string
+		name              string
+		secretData        string
+		extractJSONKey    string
+		decodeBase64      bool
+		expectedPayload   []byte
+		expectError       bool
+		expectedErrSubstr string
 	}{
 		{
 			name:            "decode base64 simple text",
@@ -104,4 +104,3 @@ func TestBase64ProcessingLogic(t *testing.T) {
 		})
 	}
 }
-

--- a/server/secretfetcher_decodebase64_test.go
+++ b/server/secretfetcher_decodebase64_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/util"
+)
+
+// TestBase64ProcessingLogic tests the base64 processing logic that would be used in secret fetching
+func TestBase64ProcessingLogic(t *testing.T) {
+	tests := []struct {
+		name               string
+		secretData         string
+		extractJSONKey     string
+		decodeBase64       bool
+		expectedPayload    []byte
+		expectError        bool
+		expectedErrSubstr  string
+	}{
+		{
+			name:            "decode base64 simple text",
+			secretData:      "aGVsbG8gd29ybGQ=", // base64 for "hello world"
+			decodeBase64:    true,
+			expectedPayload: []byte("hello world"),
+			expectError:     false,
+		},
+		{
+			name:            "decode base64 json",
+			secretData:      "eyJ1c2VyIjoiYWRtaW4iLCJwYXNzd29yZCI6InNlY3JldCJ9", // base64 for {"user":"admin","password":"secret"}
+			decodeBase64:    true,
+			expectedPayload: []byte("{\"user\":\"admin\",\"password\":\"secret\"}"),
+			expectError:     false,
+		},
+		{
+			name:            "no base64 decoding",
+			secretData:      "plain text secret",
+			decodeBase64:    false,
+			expectedPayload: []byte("plain text secret"),
+			expectError:     false,
+		},
+		{
+			name:            "extract json key and decode base64",
+			secretData:      "{\"data\":\"aGVsbG8gd29ybGQ=\"}", // JSON with base64 encoded value
+			extractJSONKey:  "data",
+			decodeBase64:    true,
+			expectedPayload: []byte("hello world"),
+			expectError:     false,
+		},
+		{
+			name:              "invalid base64",
+			secretData:        "invalid base64!!!",
+			decodeBase64:      true,
+			expectError:       true,
+			expectedErrSubstr: "failed to decode base64 content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the processing logic that happens in the fetcher
+			var content []byte
+			var err error
+
+			if tt.extractJSONKey != "" {
+				content, err = util.ExtractContentUsingJSONKey([]byte(tt.secretData), tt.extractJSONKey)
+				if err != nil {
+					if tt.expectError && tt.expectedErrSubstr != "" {
+						if !containsSubstring(err.Error(), tt.expectedErrSubstr) {
+							t.Errorf("expected error to contain %q, got %q", tt.expectedErrSubstr, err.Error())
+						}
+					} else if !tt.expectError {
+						t.Errorf("unexpected error during JSON key extraction: %v", err)
+					}
+					return
+				}
+			} else {
+				content = []byte(tt.secretData)
+			}
+
+			// Apply base64 decoding if requested
+			if tt.decodeBase64 {
+				decoded, err := util.DecodeBase64Content(content)
+				if err != nil {
+					if tt.expectError && tt.expectedErrSubstr != "" {
+						if !containsSubstring(err.Error(), tt.expectedErrSubstr) {
+							t.Errorf("expected error to contain %q, got %q", tt.expectedErrSubstr, err.Error())
+						}
+					} else if !tt.expectError {
+						t.Errorf("unexpected error during base64 decoding: %v", err)
+					}
+					return
+				}
+				content = decoded
+			}
+
+			if tt.expectError {
+				t.Errorf("expected error but got none")
+			} else {
+				if string(content) != string(tt.expectedPayload) {
+					t.Errorf("expected payload %q, got %q", string(tt.expectedPayload), string(content))
+				}
+			}
+		})
+	}
+}
+
+// containsSubstring checks if a string contains a substring
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -160,6 +160,7 @@ func handleMountEvent(ctx context.Context, creds credentials.PerRPCCredentials, 
 			Path:           secret.Path,
 			ExtractJSONKey: secret.ExtractJSONKey,
 			ExtractYAMLKey: secret.ExtractYAMLKey,
+			DecodeBase64:   secret.DecodeBase64,
 		}
 		go resourceFetcher.Orchestrator(ctx, s, &callAuth, outputChannel, &wg)
 	}

--- a/test/e2e/mount_parametermanager_test.go
+++ b/test/e2e/mount_parametermanager_test.go
@@ -19,6 +19,7 @@ package test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"math/rand"
@@ -46,6 +47,11 @@ func setupPmTestSuite() {
 	f.pmReferenceGlobalSecret2 = fmt.Sprintf("pmReferenceGlobalSecret2-%d", rand.Int31())
 	f.pmReferenceRegionalSecret1 = fmt.Sprintf("pmReferenceRegionalSecret1-%d", rand.Int31())
 	f.pmReferenceRegionalSecret2 = fmt.Sprintf("pmReferenceRegionalSecret2-%d", rand.Int31())
+
+	f.decodeBase64ParameterId = fmt.Sprintf("testdecodebase64parameter-%d", rand.Int31())
+	f.decodeBase64ParameterVersionId = fmt.Sprintf("testdecodebase64version-%d", rand.Int31())
+	f.regionalDecodeBase64ParameterId = fmt.Sprintf("testregionaldecodebase64parameter-%d", rand.Int31())
+	f.regionalDecodeBase64ParameterVersionId = fmt.Sprintf("testregionaldecodebase64version-%d", rand.Int31())
 
 	// Create global test secrets to be referred for parametermanager
 	// Path where data-files for secrets are stored
@@ -126,6 +132,21 @@ backup_pwd: __REF__(//secretmanager.googleapis.com/projects/%s/secrets/%s/versio
 	check(execCmd(exec.Command("gcloud", "parametermanager", "parameters", "versions", "create", f.parameterVersionIdJSON,
 		"--parameter", f.parameterIdJson, "--location", "global",
 		"--payload-data-from-file", parameterVersionFileJson, // And here
+		"--project", f.testProjectID)))
+
+	// Create global UNFORMATTED parameter + version with base64-encoded payload
+	// for the decodeBase64 e2e test. We use UNFORMATTED so the rendered payload
+	// is the raw base64 string, no parsing/__REF__ substitution needed.
+	decodeBase64GlobalPlain := f.decodeBase64ParameterId + "-payload"
+	decodeBase64GlobalEncoded := base64.StdEncoding.EncodeToString([]byte(decodeBase64GlobalPlain))
+	decodeBase64ParameterVersionFile := filepath.Join(f.tempDir, "decodeBase64ParameterValue")
+	check(os.WriteFile(decodeBase64ParameterVersionFile, []byte(decodeBase64GlobalEncoded), 0644))
+
+	check(execCmd(exec.Command("gcloud", "parametermanager", "parameters", "create", f.decodeBase64ParameterId,
+		"--location", "global", "--parameter-format", "UNFORMATTED", "--project", f.testProjectID)))
+	check(execCmd(exec.Command("gcloud", "parametermanager", "parameters", "versions", "create", f.decodeBase64ParameterVersionId,
+		"--parameter", f.decodeBase64ParameterId, "--location", "global",
+		"--payload-data-from-file", decodeBase64ParameterVersionFile,
 		"--project", f.testProjectID)))
 
 	// Create regional parameter and regional parameter version
@@ -220,6 +241,20 @@ backup_regional_pwd: __REF__(//secretmanager.googleapis.com/projects/%s/location
 		"--payload-data-from-file", parameterVersionFileJsonRegional, // And here
 		"--project", f.testProjectID)))
 
+	// Create regional UNFORMATTED parameter + version with base64-encoded payload
+	// for the decodeBase64 e2e test (regional endpoint already set above).
+	decodeBase64RegionalPlain := f.regionalDecodeBase64ParameterId + "-payload"
+	decodeBase64RegionalEncoded := base64.StdEncoding.EncodeToString([]byte(decodeBase64RegionalPlain))
+	decodeBase64RegionalParameterVersionFile := filepath.Join(f.tempDir, "decodeBase64RegionalParameterValue")
+	check(os.WriteFile(decodeBase64RegionalParameterVersionFile, []byte(decodeBase64RegionalEncoded), 0644))
+
+	check(execCmd(exec.Command("gcloud", "parametermanager", "parameters", "create", f.regionalDecodeBase64ParameterId,
+		"--location", f.location, "--parameter-format", "UNFORMATTED", "--project", f.testProjectID)))
+	check(execCmd(exec.Command("gcloud", "parametermanager", "parameters", "versions", "create", f.regionalDecodeBase64ParameterVersionId,
+		"--parameter", f.regionalDecodeBase64ParameterId, "--location", f.location,
+		"--payload-data-from-file", decodeBase64RegionalParameterVersionFile,
+		"--project", f.testProjectID)))
+
 	// Add a delay to allow IAM changes for Parameter Manager service identities to propagate.
 	// This is to mitigate potential 'context deadline exceeded' errors during parameter version rendering
 	// if the Parameter's service identity doesn't yet have permissions to access referenced secrets.
@@ -255,6 +290,21 @@ func teardownPmTestSuite() {
 	))
 	execCmd(exec.Command(
 		"gcloud", "parametermanager", "parameters", "delete", f.parameterIdJson,
+		"--location", "global",
+		"--project", f.testProjectID,
+		"--quiet",
+	))
+
+	// Delete the global decodeBase64 parameter + version
+	execCmd(exec.Command(
+		"gcloud", "parametermanager", "parameters", "versions", "delete", f.decodeBase64ParameterVersionId,
+		"--parameter", f.decodeBase64ParameterId,
+		"--location", "global",
+		"--project", f.testProjectID,
+		"--quiet",
+	))
+	execCmd(exec.Command(
+		"gcloud", "parametermanager", "parameters", "delete", f.decodeBase64ParameterId,
 		"--location", "global",
 		"--project", f.testProjectID,
 		"--quiet",
@@ -302,6 +352,21 @@ func teardownPmTestSuite() {
 	))
 	execCmd(exec.Command(
 		"gcloud", "parametermanager", "parameters", "delete", f.regionalParameterIdJSON,
+		"--location", f.location,
+		"--project", f.testProjectID,
+		"--quiet",
+	))
+
+	// Delete the regional decodeBase64 parameter + version (regional endpoint already set above)
+	execCmd(exec.Command(
+		"gcloud", "parametermanager", "parameters", "versions", "delete", f.regionalDecodeBase64ParameterVersionId,
+		"--parameter", f.regionalDecodeBase64ParameterId,
+		"--location", f.location,
+		"--project", f.testProjectID,
+		"--quiet",
+	))
+	execCmd(exec.Command(
+		"gcloud", "parametermanager", "parameters", "delete", f.regionalDecodeBase64ParameterId,
 		"--location", f.location,
 		"--project", f.testProjectID,
 		"--quiet",
@@ -576,5 +641,56 @@ func TestMountParameterVersionFileMode(t *testing.T) {
 		"440", // expected mode
 	); err != nil {
 		t.Fatalf("Error while testing regional json parameter version filemode: %v", err)
+	}
+}
+
+// TestMountDecodeBase64ParameterVersion verifies that parameter versions whose
+// rendered payload is base64-encoded are transparently decoded when
+// decodeBase64: true is set (both global and regional), and that the same
+// rendered payload mounted on a sibling path without the flag is left alone.
+func TestMountDecodeBase64ParameterVersion(t *testing.T) {
+	podFile := filepath.Join(f.tempDir, "test-decode-base64-pm.yaml")
+	if err := replaceTemplate("templates/test-decode-base64-pm.yaml.tmpl", podFile); err != nil {
+		t.Fatalf("Error replacing pod template: %v", err)
+	}
+
+	if err := execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile,
+		"--namespace", "default", "-f", podFile)); err != nil {
+		t.Fatalf("Error creating job: %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+	if err := execCmd(exec.Command("kubectl", "wait", "pod/test-parameter-version-mounter-decode-base64", "--for=condition=Ready",
+		"--kubeconfig", f.kubeconfigFile, "--namespace", "default", "--timeout", "5m")); err != nil {
+		t.Fatalf("Error waiting for pod test-parameter-version-mounter-decode-base64: %v", err)
+	}
+
+	wantGlobalPlain := f.decodeBase64ParameterId + "-payload"
+	wantGlobalEncoded := base64.StdEncoding.EncodeToString([]byte(wantGlobalPlain))
+
+	if err := checkMountedParameterVersion(
+		"test-parameter-version-mounter-decode-base64",
+		"/var/gcp-test-parameter-version/decoded",
+		wantGlobalPlain,
+	); err != nil {
+		t.Fatalf("Error while testing global decoded parameter version: %v", err)
+	}
+
+	// Negative control: same rendered payload, no decodeBase64 flag.
+	if err := checkMountedParameterVersion(
+		"test-parameter-version-mounter-decode-base64",
+		"/var/gcp-test-parameter-version/encoded",
+		wantGlobalEncoded,
+	); err != nil {
+		t.Fatalf("Error while testing global raw (non-decoded) parameter version: %v", err)
+	}
+
+	wantRegionalPlain := f.regionalDecodeBase64ParameterId + "-payload"
+	if err := checkMountedParameterVersion(
+		"test-parameter-version-mounter-decode-base64",
+		"/var/gcp-test-parameter-version/decoded-regional",
+		wantRegionalPlain,
+	); err != nil {
+		t.Fatalf("Error while testing regional decoded parameter version: %v", err)
 	}
 }

--- a/test/e2e/mount_secretmanager_test.go
+++ b/test/e2e/mount_secretmanager_test.go
@@ -19,6 +19,7 @@ package test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"os"
@@ -124,12 +125,23 @@ func setupSmTestSuite() {
 
 	f.testRotateSecretID = f.testSecretID + "-rotate"
 	f.testExtractSecretID = f.testSecretID + "-extract"
+	f.testDecodeBase64SecretID = f.testSecretID + "-decode-base64"
 
 	// Create test secret
 	secretFile := filepath.Join(f.tempDir, "secretValue")
 	check(os.WriteFile(secretFile, []byte(f.testSecretID), 0644))
 	check(execCmd(exec.Command("gcloud", "secrets", "create", f.testSecretID, "--replication-policy", "automatic",
 		"--data-file", secretFile, "--project", f.testProjectID)))
+
+	// Create global decodeBase64 test secret. The stored value is base64(plain),
+	// so the pod that mounts with decodeBase64: true should see plain, while a
+	// sibling mount without decodeBase64 should see the encoded value.
+	decodeBase64GlobalPlain := f.testDecodeBase64SecretID
+	decodeBase64GlobalEncoded := base64.StdEncoding.EncodeToString([]byte(decodeBase64GlobalPlain))
+	decodeBase64SecretFile := filepath.Join(f.tempDir, "decodeBase64SecretValue")
+	check(os.WriteFile(decodeBase64SecretFile, []byte(decodeBase64GlobalEncoded), 0644))
+	check(execCmd(exec.Command("gcloud", "secrets", "create", f.testDecodeBase64SecretID, "--replication-policy", "automatic",
+		"--data-file", decodeBase64SecretFile, "--project", f.testProjectID)))
 
 	// Create regional secret
 	secretFile = filepath.Join(f.tempDir, "regionalSecretValue")
@@ -140,6 +152,14 @@ func setupSmTestSuite() {
 		"https://secretmanager."+f.location+".rep.googleapis.com/")))
 	check(execCmd(exec.Command("gcloud", "secrets", "create", f.testSecretID, "--location", f.location,
 		"--data-file", secretFile, "--project", f.testProjectID)))
+
+	// Create regional decodeBase64 test secret with base64(plain) payload.
+	decodeBase64RegionalPlain := f.testDecodeBase64SecretID + "-regional"
+	decodeBase64RegionalEncoded := base64.StdEncoding.EncodeToString([]byte(decodeBase64RegionalPlain))
+	decodeBase64RegionalSecretFile := filepath.Join(f.tempDir, "decodeBase64RegionalSecretValue")
+	check(os.WriteFile(decodeBase64RegionalSecretFile, []byte(decodeBase64RegionalEncoded), 0644))
+	check(execCmd(exec.Command("gcloud", "secrets", "create", f.testDecodeBase64SecretID, "--location", f.location,
+		"--data-file", decodeBase64RegionalSecretFile, "--project", f.testProjectID)))
 
 	// Setting endpoints back to the global defaults
 	check(execCmd(exec.Command("gcloud", "config", "unset", "api_endpoint_overrides/secretmanager")))
@@ -161,6 +181,11 @@ func teardownSmTestSuite() {
 		"--project", f.testProjectID,
 		"--quiet",
 	))
+	execCmd(exec.Command(
+		"gcloud", "secrets", "delete", f.testDecodeBase64SecretID,
+		"--project", f.testProjectID,
+		"--quiet",
+	))
 
 	// Cleanup regional secret
 	check(execCmd(exec.Command("gcloud", "config", "set", "api_endpoint_overrides/secretmanager",
@@ -168,6 +193,8 @@ func teardownSmTestSuite() {
 	execCmd(exec.Command("gcloud", "secrets", "delete", f.testSecretID, "--location", f.location,
 		"--project", f.testProjectID, "--quiet"))
 	execCmd(exec.Command("gcloud", "secrets", "delete", f.testRotateSecretID, "--location", f.location,
+		"--project", f.testProjectID, "--quiet"))
+	execCmd(exec.Command("gcloud", "secrets", "delete", f.testDecodeBase64SecretID, "--location", f.location,
 		"--project", f.testProjectID, "--quiet"))
 	check(execCmd(exec.Command("gcloud", "config", "unset", "api_endpoint_overrides/secretmanager")))
 }
@@ -521,5 +548,77 @@ func TestMountExtractSecret(t *testing.T) {
 	}
 	if got := stdout.Bytes(); !bytes.Equal(got, testExtractSecret) {
 		t.Fatalf("Secret value is %v, want: %v", got, testExtractSecret)
+	}
+}
+
+// readMountedFile reads a file from a running test pod and returns its bytes.
+func readMountedFile(podName, filePath string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	command := exec.Command("kubectl", "exec", podName,
+		"--kubeconfig", f.kubeconfigFile, "--namespace", "default",
+		"--",
+		"cat", filePath)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		fmt.Println("Stdout:", stdout.String())
+		fmt.Println("Stderr:", stderr.String())
+		return nil, fmt.Errorf("could not read %s from container: %w", filePath, err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// TestMountDecodeBase64Secret verifies that secrets stored in GSM as base64 are
+// transparently decoded when decodeBase64: true is set, and that the same
+// secret mounted on a sibling path without the flag remains base64-encoded.
+func TestMountDecodeBase64Secret(t *testing.T) {
+	podFile := filepath.Join(f.tempDir, "test-decode-base64-sm.yaml")
+	if err := replaceTemplate("templates/test-decode-base64-sm.yaml.tmpl", podFile); err != nil {
+		t.Fatalf("Error replacing pod template: %v", err)
+	}
+
+	if err := execCmd(exec.Command("kubectl", "apply", "--kubeconfig", f.kubeconfigFile,
+		"--namespace", "default", "-f", podFile)); err != nil {
+		t.Fatalf("Error creating job: %v", err)
+	}
+
+	// As a workaround for https://github.com/kubernetes/kubernetes/issues/83242, we sleep to
+	// ensure that the job resources exist before attempting to wait for it.
+	time.Sleep(5 * time.Second)
+	if err := execCmd(exec.Command("kubectl", "wait", "pod/test-secret-mounter-decode-base64", "--for=condition=Ready",
+		"--kubeconfig", f.kubeconfigFile, "--namespace", "default", "--timeout", "5m")); err != nil {
+		t.Fatalf("Error waiting for job: %v", err)
+	}
+
+	// Global: stored value is base64(plain). With decodeBase64 we should see plain.
+	wantGlobalPlain := []byte(f.testDecodeBase64SecretID)
+	wantGlobalEncoded := []byte(base64.StdEncoding.EncodeToString(wantGlobalPlain))
+
+	gotGlobalDecoded, err := readMountedFile("test-secret-mounter-decode-base64", "/var/gcp-test-secrets/decoded")
+	if err != nil {
+		t.Fatalf("Error reading global decoded secret: %v", err)
+	}
+	if !bytes.Equal(gotGlobalDecoded, wantGlobalPlain) {
+		t.Fatalf("Global decoded secret = %q, want: %q", string(gotGlobalDecoded), string(wantGlobalPlain))
+	}
+
+	// Negative control: same source secret, mounted without decodeBase64.
+	// Value should still be base64-encoded so we don't accidentally decode by default.
+	gotGlobalRaw, err := readMountedFile("test-secret-mounter-decode-base64", "/var/gcp-test-secrets/encoded")
+	if err != nil {
+		t.Fatalf("Error reading raw global secret: %v", err)
+	}
+	if !bytes.Equal(gotGlobalRaw, wantGlobalEncoded) {
+		t.Fatalf("Raw global secret = %q, want: %q", string(gotGlobalRaw), string(wantGlobalEncoded))
+	}
+
+	// Regional: same shape, regional endpoint.
+	wantRegionalPlain := []byte(f.testDecodeBase64SecretID + "-regional")
+	gotRegionalDecoded, err := readMountedFile("test-secret-mounter-decode-base64", "/var/gcp-test-secrets/decoded-regional")
+	if err != nil {
+		t.Fatalf("Error reading regional decoded secret: %v", err)
+	}
+	if !bytes.Equal(gotRegionalDecoded, wantRegionalPlain) {
+		t.Fatalf("Regional decoded secret = %q, want: %q", string(gotRegionalDecoded), string(wantRegionalPlain))
 	}
 }

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -35,31 +35,36 @@ import (
 const zone = "us-central1-c"
 
 type testFixture struct {
-	tempDir             string
-	gcpProviderBranch   string
-	testClusterName     string
-	testSecretID        string
-	testRotateSecretID  string
-	testExtractSecretID string
-	kubeconfigFile      string
-	testProjectID       string
-	secretStoreVersion  string
-	gkeVersion          string
-	location            string
+	tempDir                  string
+	gcpProviderBranch        string
+	testClusterName          string
+	testSecretID             string
+	testRotateSecretID       string
+	testExtractSecretID      string
+	testDecodeBase64SecretID string
+	kubeconfigFile           string
+	testProjectID            string
+	secretStoreVersion       string
+	gkeVersion               string
+	location                 string
 
 	// below fields explicitly used for parameter manager
-	pmReferenceGlobalSecret1       string
-	pmReferenceGlobalSecret2       string
-	pmReferenceRegionalSecret1     string
-	pmReferenceRegionalSecret2     string
-	parameterIdYaml                string
-	parameterIdJson                string
-	parameterVersionIdYAML         string
-	parameterVersionIdJSON         string
-	regionalParameterIdYAML        string
-	regionalParameterIdJSON        string
-	regionalParameterVersionIdYAML string
-	regionalParameterVersionIdJSON string
+	pmReferenceGlobalSecret1               string
+	pmReferenceGlobalSecret2               string
+	pmReferenceRegionalSecret1             string
+	pmReferenceRegionalSecret2             string
+	parameterIdYaml                        string
+	parameterIdJson                        string
+	parameterVersionIdYAML                 string
+	parameterVersionIdJSON                 string
+	regionalParameterIdYAML                string
+	regionalParameterIdJSON                string
+	regionalParameterVersionIdYAML         string
+	regionalParameterVersionIdJSON         string
+	decodeBase64ParameterId                string
+	decodeBase64ParameterVersionId         string
+	regionalDecodeBase64ParameterId        string
+	regionalDecodeBase64ParameterVersionId string
 }
 
 var f testFixture
@@ -111,6 +116,12 @@ func replaceTemplate(templateFile string, destFile string) error {
 	template = strings.ReplaceAll(template, "$TEST_REGIONAL_PARAMETER_ID_JSON", f.regionalParameterIdJSON)
 	template = strings.ReplaceAll(template, "$TEST_REGIONAL_VERSION_ID_YAML", f.regionalParameterVersionIdYAML)
 	template = strings.ReplaceAll(template, "$TEST_REGIONAL_VERSION_ID_JSON", f.regionalParameterVersionIdJSON)
+
+	template = strings.ReplaceAll(template, "$TEST_DECODE_BASE64_SECRET_ID", f.testDecodeBase64SecretID)
+	template = strings.ReplaceAll(template, "$TEST_DECODE_BASE64_PARAMETER_ID", f.decodeBase64ParameterId)
+	template = strings.ReplaceAll(template, "$TEST_DECODE_BASE64_VERSION_ID", f.decodeBase64ParameterVersionId)
+	template = strings.ReplaceAll(template, "$TEST_REGIONAL_DECODE_BASE64_PARAMETER_ID", f.regionalDecodeBase64ParameterId)
+	template = strings.ReplaceAll(template, "$TEST_REGIONAL_DECODE_BASE64_VERSION_ID", f.regionalDecodeBase64ParameterVersionId)
 	return os.WriteFile(destFile, []byte(template), 0644)
 }
 

--- a/test/e2e/templates/test-decode-base64-pm.yaml.tmpl
+++ b/test/e2e/templates/test-decode-base64-pm.yaml.tmpl
@@ -1,0 +1,63 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-cluster-sa
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-test-parameter-version-decode-base64
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/locations/global/parameters/$TEST_DECODE_BASE64_PARAMETER_ID/versions/$TEST_DECODE_BASE64_VERSION_ID"
+        path: "decoded"
+        decodeBase64: true
+      - resourceName: "projects/$PROJECT_ID/locations/$LOCATION_ID/parameters/$TEST_REGIONAL_DECODE_BASE64_PARAMETER_ID/versions/$TEST_REGIONAL_DECODE_BASE64_VERSION_ID"
+        path: "decoded-regional"
+        decodeBase64: true
+      - resourceName: "projects/$PROJECT_ID/locations/global/parameters/$TEST_DECODE_BASE64_PARAMETER_ID/versions/$TEST_DECODE_BASE64_VERSION_ID"
+        path: "encoded"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-parameter-version-mounter-decode-base64
+spec:
+  serviceAccountName: test-cluster-sa
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: test-parameter-version-mounter
+    resources:
+      requests:
+        cpu: 50m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: "/var/gcp-test-parameter-version"
+      name: gcp-test-parameter-version
+  volumes:
+  - name: gcp-test-parameter-version
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "gcp-test-parameter-version-decode-base64"

--- a/test/e2e/templates/test-decode-base64-sm.yaml.tmpl
+++ b/test/e2e/templates/test-decode-base64-sm.yaml.tmpl
@@ -1,0 +1,63 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-cluster-sa
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-test-secrets-decode-base64
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/$PROJECT_ID/secrets/$TEST_DECODE_BASE64_SECRET_ID/versions/latest"
+        path: "decoded"
+        decodeBase64: true
+      - resourceName: "projects/$PROJECT_ID/locations/$LOCATION_ID/secrets/$TEST_DECODE_BASE64_SECRET_ID/versions/latest"
+        path: "decoded-regional"
+        decodeBase64: true
+      - resourceName: "projects/$PROJECT_ID/secrets/$TEST_DECODE_BASE64_SECRET_ID/versions/latest"
+        path: "encoded"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-mounter-decode-base64
+spec:
+  serviceAccountName: test-cluster-sa
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: test-secret-mounter
+    resources:
+      requests:
+        cpu: 50m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: "/var/gcp-test-secrets"
+      name: gcp-test-secrets
+  volumes:
+  - name: gcp-test-secrets
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "gcp-test-secrets-decode-base64"

--- a/util/key_extractor.go
+++ b/util/key_extractor.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -56,4 +57,12 @@ func getValue(key string, value any) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unsupported value type for key '%s'", key)
 	}
+}
+
+func DecodeBase64Content(payload []byte) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(string(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64 content: %v", err)
+	}
+	return decoded, nil
 }

--- a/util/key_extractor.go
+++ b/util/key_extractor.go
@@ -62,7 +62,7 @@ func getValue(key string, value any) ([]byte, error) {
 func DecodeBase64Content(payload []byte) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(string(payload))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode base64 content: %v", err)
+		return nil, fmt.Errorf("failed to decode base64 content")
 	}
 	return decoded, nil
 }


### PR DESCRIPTION
This PR adds a new `decodeBase64` field to the Secret configuration that allows automatic base64 decoding of secret values retrieved from GSM and Parameter Manager before mounting them to pods.


## Motivation

 We use a third-party service that stores secrets in GSM in base64-encoded format. Currently, when these secrets are mounted to pods, they remain base64-encoded, requiring additional decoding steps within the application. This feature removes that extra step by decoding the values directly in the CSI driver.