### PR TITLE
Avoid unconfigurable initContainer image and leverage k8s-builtin fsGroup

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -21,16 +21,6 @@ spec:
         {{- include "secrets-store-csi-driver-provider-gcp.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
-      initContainers:
-      - name: chown-provider-mount
-        image: busybox
-        command:
-        - chown
-        - "1000:1000"
-        - /etc/kubernetes/secrets-store-csi-providers
-        volumeMounts:
-        - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
-          name: providervol
       hostNetwork: false
       hostPID: false
       hostIPC: false
@@ -44,6 +34,7 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+            fsGroup: 1000
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             seccompProfile:


### PR DESCRIPTION
This `securityContext.fsGroup` does the same thing as an initContainer chowning, but:
* requires Kubernetes 1.22+
* doesn't require running a container as root
* doesn't require access to the internet for this busybox image