### PR TITLE
Avoid unconfigurable namespace is use helm's builtin

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "secrets-store-csi-driver-provider-gcp.daemonSetName" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
 spec:

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "secrets-store-csi-driver-provider-gcp.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
This effectively changes the default namespace for the resources to `default` from `kube-system`, but makes it so folks can apply this to *any* namespace.

If it is very important to maintain the default, I can add conditionals everywhere.