### PR TITLE
feat: Make busybox init container image configurable in Helm chart

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -23,7 +23,8 @@ spec:
       serviceAccountName: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
       initContainers:
       - name: chown-provider-mount
-        image: busybox
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+        imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
         command:
         - chown
         - "1000:1000"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -9,6 +9,12 @@ image:
   pullPolicy: IfNotPresent
   hash: sha256:183c92fbe7905ebe09ccec6496e91b7b615b1e88096576bc100d46fe97fe9770
 
+initContainer:
+  image:
+    repository: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+
 app: csi-secrets-store-provider-gcp
 
 podAnnotations: {}

--- a/manifest_staging/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -23,7 +23,8 @@ spec:
       serviceAccountName: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
       initContainers:
       - name: chown-provider-mount
-        image: busybox
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+        imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
         command:
         - chown
         - "1000:1000"

--- a/manifest_staging/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -9,6 +9,12 @@ image:
   pullPolicy: IfNotPresent
   hash: sha256:183c92fbe7905ebe09ccec6496e91b7b615b1e88096576bc100d46fe97fe9770
 
+initContainer:
+  image:
+    repository: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+
 app: csi-secrets-store-provider-gcp
 
 podAnnotations: {}


### PR DESCRIPTION
  ## Summary
  - Makes the busybox init container image configurable via Helm values
  - Previously, the busybox image was hardcoded in the DaemonSet template, preventing customization
  - Adds `initContainer.image` configuration section to values.yaml with repository, tag, and
  pullPolicy options

  ## Motivation
  When deploying this chart in a GKE cluster without internet access, the
  hardcoded `busybox` image cannot be pulled from Docker Hub. This change allows users to override the image source to use private registries.