### PR TITLE
Make the init/chown image configurable

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
       initContainers:
       - name: chown-provider-mount
-        image: busybox
+        image: "{{ .Values.initImage.repository }}"
         command:
         - chown
         - "1000:1000"

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -8,6 +8,8 @@ image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
   pullPolicy: IfNotPresent
   hash: sha256:c506476df12f50d6749167562cfb18af935ce8dd7a5b1006a313519dd021ecfd
+initImage:
+  repository: busybox
 
 app: csi-secrets-store-provider-gcp
 


### PR DESCRIPTION
This is a backwards-compatible change to make the helm chart init/chown image configurable, defaulting to what was there before, the unqualified `busybox` tag.

In lieu of #597 